### PR TITLE
Fix idle timeout allowExitOnIdle tests

### DIFF
--- a/packages/v-pool/test/idle-timeout-exit.js
+++ b/packages/v-pool/test/idle-timeout-exit.js
@@ -11,6 +11,6 @@ if (module === require.main) {
   })
 
   setTimeout(() => {
-    pool.query('SELECT * from generate_series(0, 1000)', (err, res) => console.log('completed second'))
+    pool.query('SELECT 40/25', (err, res) => console.log('completed second'))
   }, 50)
 }


### PR DESCRIPTION
In pg-pool/test/idle-timeout.js these tests were failing:

unrefs the connections and timeouts so the program can exit when idle when the allowExitOnIdle option is set
keeps old behavior when allowExitOnIdle option is not set

This was simply due to the statement being used being not supported in vertica. Changed to another example as the details of the query don't matter.