### PR TITLE
Change pg_sleep into sleep, updating decimals to be integers

### DIFF
--- a/packages/v-pool/test/error-handling.js
+++ b/packages/v-pool/test/error-handling.js
@@ -236,7 +236,7 @@ describe('pool error handling', function () {
     pool.on('error', () => {
       // We double close the connection in this test, prevent exception caused by that
     })
-    pool.query('SELECT pg_sleep(5)', [], (err) => {
+    pool.query('SELECT sleep(5)', [], (err) => {
       expect(err).to.be.an(Error)
       done()
     })

--- a/packages/v-pool/test/lifetime-timeout.js
+++ b/packages/v-pool/test/lifetime-timeout.js
@@ -21,7 +21,7 @@ describe('lifetime timeout', () => {
   })
   it('connection lifetime should expire and remove the client after the client is done working', (done) => {
     const pool = new Pool({ maxLifetimeSeconds: 1 })
-    pool.query('SELECT pg_sleep(1.01)')
+    pool.query('SELECT sleep(2)')
     pool.on('remove', () => {
       console.log('expired while busy - on-remove event')
       expect(pool.expiredCount).to.equal(0)
@@ -33,7 +33,7 @@ describe('lifetime timeout', () => {
     'can remove expired clients and recreate them',
     co.wrap(function* () {
       const pool = new Pool({ maxLifetimeSeconds: 1 })
-      let query = pool.query('SELECT pg_sleep(1)')
+      let query = pool.query('SELECT sleep(1)')
       expect(pool.expiredCount).to.equal(0)
       expect(pool.totalCount).to.equal(1)
       yield query

--- a/packages/vertica-nodejs/test/integration/client/api-tests.js
+++ b/packages/vertica-nodejs/test/integration/client/api-tests.js
@@ -53,7 +53,7 @@ suite.test('query timeout', (cb) => {
   const pool = new vertica.Pool({ query_timeout: 1000 })
   pool.connect().then((client) => {
     client.query(
-      'SELECT pg_sleep(2)',
+      'SELECT sleep(2)',
       assert.calls(function (err, result) {
         assert(err)
         assert(err.message === 'Query read timeout')
@@ -68,7 +68,7 @@ suite.test('query recover from timeout', (cb) => {
   const pool = new vertica.Pool({ query_timeout: 1000 })
   pool.connect().then((client) => {
     client.query(
-      'SELECT pg_sleep(20)',
+      'SELECT sleep(20)',
       assert.calls(function (err, result) {
         assert(err)
         assert(err.message === 'Query read timeout')
@@ -92,7 +92,7 @@ suite.test('query no timeout', (cb) => {
   const pool = new vertica.Pool({ query_timeout: 10000 })
   pool.connect().then((client) => {
     client.query(
-      'SELECT pg_sleep(1)',
+      'SELECT sleep(1)',
       assert.calls(function (err, result) {
         assert(!err)
         client.release()

--- a/packages/vertica-nodejs/test/integration/client/error-handling-tests.js
+++ b/packages/vertica-nodejs/test/integration/client/error-handling-tests.js
@@ -82,7 +82,7 @@ suite.test('query receives error on client shutdown', function (done) {
   client.connect(
     assert.success(function () {
       const config = {
-        text: 'select pg_sleep(5)',
+        text: 'select sleep(5)',
         name: 'foobar',
       }
       let queryError

--- a/packages/vertica-nodejs/test/integration/client/query-error-handling-prepared-statement-tests.js
+++ b/packages/vertica-nodejs/test/integration/client/query-error-handling-prepared-statement-tests.js
@@ -9,7 +9,7 @@ suite.test('client end during query execution of prepared statement', function (
   var client = new Client()
   client.connect(
     assert.success(function () {
-      var sleepQuery = 'select pg_sleep($1)'
+      var sleepQuery = 'select sleep($1)'
 
       var queryConfig = {
         name: 'sleep query',
@@ -89,7 +89,7 @@ suite.test('query killed during query execution of prepared statement', function
   var client = new Client(helper.args)
   client.connect(
     assert.success(function () {
-      var sleepQuery = 'select pg_sleep($1)'
+      var sleepQuery = 'select sleep($1)'
 
       const queryConfig = {
         name: 'sleep query',

--- a/packages/vertica-nodejs/test/integration/client/query-error-handling-tests.js
+++ b/packages/vertica-nodejs/test/integration/client/query-error-handling-tests.js
@@ -8,7 +8,7 @@ test('error during query execution', function () {
   var client = new Client(helper.args)
   client.connect(
     assert.success(function () {
-      var queryText = 'select pg_sleep(10)'
+      var queryText = 'select sleep(10)'
       var sleepQuery = new Query(queryText)
       var pidColName = 'procpid'
       var queryColName = 'current_query'

--- a/packages/vertica-nodejs/test/integration/client/statement_timeout-tests.js
+++ b/packages/vertica-nodejs/test/integration/client/statement_timeout-tests.js
@@ -73,7 +73,7 @@ if (!helper.args.native) {
     var client = new Client(conf)
     client.connect(
       assert.success(function () {
-        client.query('SELECT pg_sleep( 1 )', function (error) {
+        client.query('SELECT sleep( 1 )', function (error) {
           client.end()
           assert.strictEqual(error.code, '57014') // query_cancelled
           done()

--- a/packages/vertica-nodejs/test/integration/connection-pool/error-tests.js
+++ b/packages/vertica-nodejs/test/integration/connection-pool/error-tests.js
@@ -141,7 +141,7 @@ suite.test('handles socket error during pool.query and destroys it immediately',
   const pool = new vertica.Pool({ max: 1 })
 
   if (native) {
-    pool.query('SELECT pg_sleep(10)', [], (err) => {
+    pool.query('SELECT sleep(10)', [], (err) => {
       assert.equal(err.message, 'canceling statement due to user request')
       cb()
     })
@@ -152,7 +152,7 @@ suite.test('handles socket error during pool.query and destroys it immediately',
       })
     }, 100)
   } else {
-    pool.query('SELECT pg_sleep(10)', [], (err) => {
+    pool.query('SELECT sleep(10)', [], (err) => {
       assert.equal(err.message, 'network issue')
       assert.equal(stream.destroyed, true)
       cb()


### PR DESCRIPTION
since pg_sleep has a numeric parameter and vertica's sleep has an integer, there was one case where I needed to change the input value to be a decimal. Everything else is just simple text replacement