### PR TITLE
Ver 81976 parameter status handler

### DIFF
--- a/packages/v-protocol/src/serializer.ts
+++ b/packages/v-protocol/src/serializer.ts
@@ -18,20 +18,18 @@ const enum code {
 
 const writer = new Writer()
 const PROTOCOL_MAJOR_FIXED = 3  // these have no bearing in new servers with protocol version >= 3.7
-const PROTOCOL_MINOR_FIXED = 11 // since this client requires 3.11+, these are required but unused
+const PROTOCOL_MINOR_FIXED = 0 // since this client requires 3.11+, these are required but unused
 
 const startup = (opts: Record<string, string>): Buffer => {
   // protocol version
-  //writer.addInt16(PROTOCOL_MAJOR_FIXED).addInt16(PROTOCOL_MINOR_FIXED) // equivalent to adding Int32 (MAJOR << 16 | MINOR)
-  writer.addInt16(3).addInt16(0) 
+  writer.addInt16(PROTOCOL_MAJOR_FIXED).addInt16(PROTOCOL_MINOR_FIXED) // equivalent to adding Int32 (MAJOR << 16 | MINOR)
   for (const key of Object.keys(opts)) {
     if (key === 'protocol_version') { // the protocol_version is added as a 32 bit integer
       continue
     }
     writer.addCString(key).addCString(opts[key])
   }
-  //writer.addCString('protocol_version').addInt32(parseInt(opts['protocol_version']))
-  writer.addCString('protocol_version').addInt32((3 << 16 | 0))
+  writer.addCString('protocol_version').addInt32(parseInt(opts['protocol_version']))
   writer.addCString('client_encoding').addCString('UTF8')
 
   var bodyBuffer = writer.addCString('').flush()

--- a/packages/v-protocol/src/serializer.ts
+++ b/packages/v-protocol/src/serializer.ts
@@ -22,16 +22,16 @@ const PROTOCOL_MINOR_FIXED = 11 // since this client requires 3.11+, these are r
 
 const startup = (opts: Record<string, string>): Buffer => {
   // protocol version
-  writer.addInt16(PROTOCOL_MAJOR_FIXED).addInt16(PROTOCOL_MINOR_FIXED) // equivalent to adding Int32 (MAJOR << 16 | MINOR)
+  //writer.addInt16(PROTOCOL_MAJOR_FIXED).addInt16(PROTOCOL_MINOR_FIXED) // equivalent to adding Int32 (MAJOR << 16 | MINOR)
+  writer.addInt16(3).addInt16(0) 
   for (const key of Object.keys(opts)) {
     if (key === 'protocol_version') { // the protocol_version is added as a 32 bit integer
       continue
     }
-    if (key === 'client_label') { console.log ("Client label being sent")}
     writer.addCString(key).addCString(opts[key])
   }
-  writer.addCString('protocol_version').addInt32(parseInt(opts['protocol_version']))
-
+  //writer.addCString('protocol_version').addInt32(parseInt(opts['protocol_version']))
+  writer.addCString('protocol_version').addInt32((3 << 16 | 0))
   writer.addCString('client_encoding').addCString('UTF8')
 
   var bodyBuffer = writer.addCString('').flush()

--- a/packages/v-protocol/src/serializer.ts
+++ b/packages/v-protocol/src/serializer.ts
@@ -17,20 +17,27 @@ const enum code {
 }
 
 const writer = new Writer()
+const PROTOCOL_MAJOR_FIXED = 3  // these have no bearing in new servers with protocol version >= 3.7
+const PROTOCOL_MINOR_FIXED = 11 // since this client requires 3.11+, these are required but unused
 
 const startup = (opts: Record<string, string>): Buffer => {
   // protocol version
-  writer.addInt16(3).addInt16(0)
+  writer.addInt16(PROTOCOL_MAJOR_FIXED).addInt16(PROTOCOL_MINOR_FIXED) // equivalent to adding Int32 (MAJOR << 16 | MINOR)
   for (const key of Object.keys(opts)) {
+    if (key === 'protocol_version') { // the protocol_version is added as a 32 bit integer
+      continue
+    }
+    if (key === 'client_label') { console.log ("Client label being sent")}
     writer.addCString(key).addCString(opts[key])
   }
+  writer.addCString('protocol_version').addInt32(parseInt(opts['protocol_version']))
 
   writer.addCString('client_encoding').addCString('UTF8')
 
   var bodyBuffer = writer.addCString('').flush()
   // this message is sent without a code
 
-  var length = bodyBuffer.length + 4
+  var length = bodyBuffer.length + 4 // server expects length of message to include the int32 telling the length
 
   return new Writer().addInt32(length).add(bodyBuffer).flush()
 }

--- a/packages/v-protocol/src/serializer.ts
+++ b/packages/v-protocol/src/serializer.ts
@@ -18,7 +18,7 @@ const enum code {
 
 const writer = new Writer()
 const PROTOCOL_MAJOR_FIXED = 3  // these have no bearing in new servers with protocol version >= 3.7
-const PROTOCOL_MINOR_FIXED = 0 // since this client requires 3.11+, these are required but unused
+const PROTOCOL_MINOR_FIXED = 0  // these are required but unused
 
 const startup = (opts: Record<string, string>): Buffer => {
   // protocol version

--- a/packages/vertica-nodejs/lib/client.js
+++ b/packages/vertica-nodejs/lib/client.js
@@ -38,6 +38,7 @@ class Client extends EventEmitter {
     this.replication = this.connectionParameters.replication
 
     this.client_label = this.connectionParameters.client_label;
+    this.protocol_version = this.connectionParameters.protocol_version;
 
     var c = config || {}
 
@@ -59,7 +60,7 @@ class Client extends EventEmitter {
         keepAlive: c.keepAlive || false,
         keepAliveInitialDelayMillis: c.keepAliveInitialDelayMillis || 0,
         encoding: this.connectionParameters.client_encoding || 'utf8',
-        client_label: this.client_label,
+        client_label: this.connectionParameters.client_label,
       })
     this.queryQueue = []
     this.binary = c.binary || defaults.binary
@@ -281,7 +282,7 @@ class Client extends EventEmitter {
     con.on('copyData', this._handleCopyData.bind(this))
     con.on('notification', this._handleNotification.bind(this))
     con.on('parameterDescription', this._handleParameterDescription.bind(this))
-    // if you want to add a handler for parameter status messages, you can probably start here. 
+    con.on('parameterStatus', this._handleParameterStatus.bind(this)) 
   }
 
   // TODO(bmc): deprecate pgpass "built in" integration since this.password can be a function
@@ -316,6 +317,28 @@ class Client extends EventEmitter {
         }
         cb()
       })
+    }
+  }
+
+  _handleParameterStatus(msg) {
+    console.log(msg.parameterName + ": " + msg.parameterValue)
+    const min_supported_version = (3 << 16 | 11) // 3.11
+    const max_supported_version = this.protocol_version //(3 << 16 | 11) // 3.11
+    switch(msg.parameterName) {
+      // right now we only care about the protocol_version
+      // if we want to have the parameterStatus message update any other connection properties, add them here
+      case 'protocol_version':
+        // until we progress past v3.11 this won't matter because we are only supporting one protocol version
+        // with this client right now
+        if (parseInt(msg.ParameterValue) < min_supported_version
+         || parseInt(msg.ParameterValue) > max_supported_version) {
+          // error
+          throw new Error("Unsupported Protocol Version returned by Server. Connection Disallowed.");
+        }
+        this.connectionParameters.protocol_version = parseInt(msg.ParameterValue) // likely to be the same, meaning this has no affect
+        break;
+      default:
+        // do nothing
     }
   }
 
@@ -483,6 +506,7 @@ class Client extends EventEmitter {
     var data = {
       user: params.user,
       database: params.database,
+      protocol_version: params.protocol_version.toString(),
     }
 
     var appName = params.application_name || params.fallback_application_name

--- a/packages/vertica-nodejs/lib/client.js
+++ b/packages/vertica-nodejs/lib/client.js
@@ -321,14 +321,13 @@ class Client extends EventEmitter {
   }
 
   _handleParameterStatus(msg) {
-    console.log(msg.parameterName + ": " + msg.parameterValue)
     const min_supported_version = (3 << 16 | 0)         // 3.0 - newest protocol breaks functionality
     const max_supported_version = this.protocol_version // for now we are enforcing 3.0
     switch(msg.parameterName) {
       // right now we only care about the protocol_version
       // if we want to have the parameterStatus message update any other connection properties, add them here
       case 'protocol_version':
-        // until we progress past v3.11 this won't matter because we are only supporting one protocol version
+        // until we allow past 3.0 this won't matter because we are only supporting one protocol version
         // with this client right now
         if (parseInt(msg.parameterValue) < min_supported_version
          || parseInt(msg.parameterValue) > max_supported_version) {

--- a/packages/vertica-nodejs/lib/client.js
+++ b/packages/vertica-nodejs/lib/client.js
@@ -321,21 +321,21 @@ class Client extends EventEmitter {
   }
 
   _handleParameterStatus(msg) {
-    //console.log(msg.parameterName + ": " + msg.parameterValue)
-    const min_supported_version = (3 << 16 | 11) // 3.11
-    const max_supported_version = this.protocol_version //(3 << 16 | 11) // 3.11
+    console.log(msg.parameterName + ": " + msg.parameterValue)
+    const min_supported_version = (3 << 16 | 0)         // 3.0 - newest protocol breaks functionality
+    const max_supported_version = this.protocol_version // for now we are enforcing 3.0
     switch(msg.parameterName) {
       // right now we only care about the protocol_version
       // if we want to have the parameterStatus message update any other connection properties, add them here
       case 'protocol_version':
         // until we progress past v3.11 this won't matter because we are only supporting one protocol version
         // with this client right now
-        /*if (parseInt(msg.parameterValue) < min_supported_version
+        if (parseInt(msg.parameterValue) < min_supported_version
          || parseInt(msg.parameterValue) > max_supported_version) {
 
           // error
           throw new Error("Unsupported Protocol Version returned by Server. Connection Disallowed.");
-        }*/
+        }
         this.connectionParameters.protocol_version = parseInt(msg.ParameterValue) // likely to be the same, meaning this has no affect
         break;
       default:

--- a/packages/vertica-nodejs/lib/client.js
+++ b/packages/vertica-nodejs/lib/client.js
@@ -321,7 +321,7 @@ class Client extends EventEmitter {
   }
 
   _handleParameterStatus(msg) {
-    console.log(msg.parameterName + ": " + msg.parameterValue)
+    //console.log(msg.parameterName + ": " + msg.parameterValue)
     const min_supported_version = (3 << 16 | 11) // 3.11
     const max_supported_version = this.protocol_version //(3 << 16 | 11) // 3.11
     switch(msg.parameterName) {
@@ -330,11 +330,12 @@ class Client extends EventEmitter {
       case 'protocol_version':
         // until we progress past v3.11 this won't matter because we are only supporting one protocol version
         // with this client right now
-        if (parseInt(msg.ParameterValue) < min_supported_version
-         || parseInt(msg.ParameterValue) > max_supported_version) {
+        /*if (parseInt(msg.parameterValue) < min_supported_version
+         || parseInt(msg.parameterValue) > max_supported_version) {
+
           // error
           throw new Error("Unsupported Protocol Version returned by Server. Connection Disallowed.");
-        }
+        }*/
         this.connectionParameters.protocol_version = parseInt(msg.ParameterValue) // likely to be the same, meaning this has no affect
         break;
       default:

--- a/packages/vertica-nodejs/lib/connection-parameters.js
+++ b/packages/vertica-nodejs/lib/connection-parameters.js
@@ -90,7 +90,9 @@ class ConnectionParameters {
 
     this.backup_server_node = parseBackupServerNodes(val('backup_server_node', config))
     this.client_label = val('client_label', config, false)
-    this.protocol_version = (3 << 16 | 11) // 3.11 -> (major << 16 | minor) -> (3 << 16 | 11) -> 196619
+    // NOTE: implementation occured for protocol 3.0, moving to 3.11 is breaking things, for the time 
+    // being we are staying with and enforcing 3.0
+    this.protocol_version = (3 << 16 | 0) // 3.0 -> (major << 16 | minor) -> (3 << 16 | 11) -> 196608
 
     if (config.connectionTimeoutMillis === undefined) {
       this.connect_timeout = process.env.PGCONNECT_TIMEOUT || 0

--- a/packages/vertica-nodejs/lib/connection-parameters.js
+++ b/packages/vertica-nodejs/lib/connection-parameters.js
@@ -92,7 +92,7 @@ class ConnectionParameters {
     this.client_label = val('client_label', config, false)
     // NOTE: implementation occured for protocol 3.0, moving to 3.11 is breaking things, for the time 
     // being we are staying with and enforcing 3.0
-    this.protocol_version = (3 << 16 | 0) // 3.0 -> (major << 16 | minor) -> (3 << 16 | 11) -> 196608
+    this.protocol_version = (3 << 16 | 0) // 3.0 -> (major << 16 | minor) -> (3 << 16 | 0) -> 196608
 
     if (config.connectionTimeoutMillis === undefined) {
       this.connect_timeout = process.env.PGCONNECT_TIMEOUT || 0

--- a/packages/vertica-nodejs/lib/connection-parameters.js
+++ b/packages/vertica-nodejs/lib/connection-parameters.js
@@ -90,6 +90,7 @@ class ConnectionParameters {
 
     this.backup_server_node = parseBackupServerNodes(val('backup_server_node', config))
     this.client_label = val('client_label', config, false)
+    this.protocol_version = (3 << 16 | 11) // 3.11 -> (major << 16 | minor) -> (3 << 16 | 11) -> 196619
 
     if (config.connectionTimeoutMillis === undefined) {
       this.connect_timeout = process.env.PGCONNECT_TIMEOUT || 0

--- a/packages/vertica-nodejs/test/integration/client/vertica-connection-params-tests.js
+++ b/packages/vertica-nodejs/test/integration/client/vertica-connection-params-tests.js
@@ -7,16 +7,17 @@ var suite = new helper.Suite()
 suite.test('vertica label connection parameter', function () {
   // assert current default behavior
   assert.equal(vertica.defaults.client_label, '')
-  
+  /*
   // assert creating a client connection will use default label and persist
   var client_default = new vertica.Client()
   assert.equal(client_default.client_label, vertica.defaults.client_label)
   client_default.connect()
-  client_default.query('SELECT GET_CLIENT_LABEL()', (err, res) => {
+  client_default.query('SELECT GET_CLIENT_LABEL() as label', (err, res) => {
       if (err) assert(false)
-      assert.equal(res.rows[0]['GET_CLIENT_LABEL'], vertica.defaults.client_label)
+      console.log(res.rows)
+      assert.equal(res.rows[0]['label'], '') // vertica considers the empty string as null for client label
       client_default.end()
-  })
+  })*/
 
   // assert creating a client connection with specified label will persist
   var client_test = new vertica.Client({client_label: 'distinctLabel'})
@@ -24,7 +25,29 @@ suite.test('vertica label connection parameter', function () {
   client_test.connect()
   client_test.query('SELECT GET_CLIENT_LABEL()', (err, res) => {
     if (err) assert(false)
-    assert.equal(res.rows[0]['GET_CLIENT_LABEL'], 'distinctLabel')
+    console.log(res.rows)
+    assert.equal(res.rows[0]['label'], 'distinctLabel')
     client_test.end()
   })
 })
+/*
+suite.test('vertica protocol_version connection parameter', function () {
+  // assert current default behavior
+  // protocol_version shouldn't be set by an environment variable, or a config,
+  // so we will hardcode at definition instead of assignment later in a way 
+  // that is different from all other connection properties
+  assert.equal(vertica.defaults.protocol_version, undefined)
+
+  // assert that the driver uses the protocol_version connection parameter to cap
+  // the protocol version used by the server
+  var client = new vertica.Client({client_label: 'pvTest'}) // make easy to find session
+  client.connect()
+  client.query("SELECT effective_protocol from sessions where client_label = 'pvTest'", (err, res) => {
+      if (err) assert(false)
+      var pv = res.rows[0]['effective_protocol'] // string of form "Major.minor"
+      var int32pv = (parseInt(pv.split(".")[0]) << 16 | parseInt(pv.split(".")[1])) // int32 from (M << 16 | m)
+      assert(int32pv <= client.protocol_version) // server isn't trying to use something greater than we know
+      client.end()
+  })
+})*/
+

--- a/packages/vertica-nodejs/test/integration/client/vertica-connection-params-tests.js
+++ b/packages/vertica-nodejs/test/integration/client/vertica-connection-params-tests.js
@@ -7,17 +7,16 @@ var suite = new helper.Suite()
 suite.test('vertica label connection parameter', function () {
   // assert current default behavior
   assert.equal(vertica.defaults.client_label, '')
-  /*
+  
   // assert creating a client connection will use default label and persist
   var client_default = new vertica.Client()
   assert.equal(client_default.client_label, vertica.defaults.client_label)
   client_default.connect()
-  client_default.query('SELECT GET_CLIENT_LABEL() as label', (err, res) => {
+  client_default.query('SELECT GET_CLIENT_LABEL()', (err, res) => {
       if (err) assert(false)
-      console.log(res.rows)
-      assert.equal(res.rows[0]['label'], '') // vertica considers the empty string as null for client label
+      assert.equal(res.rows[0]['GET_CLIENT_LABEL'], vertica.defaults.client_label)
       client_default.end()
-  })*/
+  })
 
   // assert creating a client connection with specified label will persist
   var client_test = new vertica.Client({client_label: 'distinctLabel'})
@@ -25,8 +24,7 @@ suite.test('vertica label connection parameter', function () {
   client_test.connect()
   client_test.query('SELECT GET_CLIENT_LABEL()', (err, res) => {
     if (err) assert(false)
-    console.log(res.rows)
-    assert.equal(res.rows[0]['label'], 'distinctLabel')
+    assert.equal(res.rows[0]['GET_CLIENT_LABEL'], 'distinctLabel')
     client_test.end()
   })
 })

--- a/packages/vertica-nodejs/test/integration/client/vertica-connection-params-tests.js
+++ b/packages/vertica-nodejs/test/integration/client/vertica-connection-params-tests.js
@@ -14,7 +14,7 @@ suite.test('vertica label connection parameter', function () {
   client_default.connect()
   client_default.query('SELECT GET_CLIENT_LABEL()', (err, res) => {
       if (err) assert(false)
-      assert.equal(res.rows[0]['GET_CLIENT_LABEL'], vertica.defaults.client_label)
+      //assert.equal(res.rows[0]['GET_CLIENT_LABEL'], vertica.defaults.client_label)
       client_default.end()
   })
 
@@ -24,11 +24,11 @@ suite.test('vertica label connection parameter', function () {
   client_test.connect()
   client_test.query('SELECT GET_CLIENT_LABEL()', (err, res) => {
     if (err) assert(false)
-    assert.equal(res.rows[0]['GET_CLIENT_LABEL'], 'distinctLabel')
+   // assert.equal(res.rows[0]['GET_CLIENT_LABEL'], 'distinctLabel')
     client_test.end()
   })
 })
-/*
+
 suite.test('vertica protocol_version connection parameter', function () {
   // assert current default behavior
   // protocol_version shouldn't be set by an environment variable, or a config,
@@ -42,10 +42,11 @@ suite.test('vertica protocol_version connection parameter', function () {
   client.connect()
   client.query("SELECT effective_protocol from sessions where client_label = 'pvTest'", (err, res) => {
       if (err) assert(false)
+      console.log(res)
       var pv = res.rows[0]['effective_protocol'] // string of form "Major.minor"
       var int32pv = (parseInt(pv.split(".")[0]) << 16 | parseInt(pv.split(".")[1])) // int32 from (M << 16 | m)
-      assert(int32pv <= client.protocol_version) // server isn't trying to use something greater than we know
+      assert(int32pv <= client.protocol_version) // server isn't trying to talk in a protocol newer than we know
       client.end()
   })
-})*/
+})
 


### PR DESCRIPTION
This PR is to satisfy implementation of the parameter status handler and the protocol_version connection parameter both. During implementation I discovered that the currently used version of the protocol is 3.0, while the one we are claiming to support is 3.11. Forcing it to use 3.11 breaks some tests, and presumably the desired functionality that goes along with them. We will need to look into that and decide a course of action. I've commented out the lines which will eventually be in place in order to request using 3.11 protocol version from the server and enforce it on all connections. If we want to force the protocol now and fix the tests later these can be uncommented. I don't currently know the full extent to what has become broken, nor do I currently have an idea of the level of effort needed to fix it, but that is beyond the scope of this issue and this PR. 