### PR TITLE
Modified timeout needed from sleep update

### DIFF
--- a/packages/v-pool/test/lifetime-timeout.js
+++ b/packages/v-pool/test/lifetime-timeout.js
@@ -28,7 +28,7 @@ describe('lifetime timeout', () => {
       expect(pool.totalCount).to.equal(0)
       done()
     })
-  })
+  }).timeout(3000)
   it(
     'can remove expired clients and recreate them',
     co.wrap(function* () {


### PR DESCRIPTION
This was originally logged as a failure because pg_sleep was being used and the extra time it took to error out was causing a timeout of the default 2000ms. When updating to use vertica's sleep meta function, the timeout persisted because Vertica's sleep function only takes integers compared to pg_sleep which accepts double precision. For that reason we had to sleep for 2 seconds instead of 1.01 seconds, and 2 seconds already hits the default max of 2000ms. So for that reason I needed to force the default timeout to be 3 seconds. There are a lot of different ways mocha advertises being able to change the timeout, but there are unresolved conflictions with certain plugins and when using arrow functions and more. This was the simplest way that worked. 