### PR TITLE
Add support for SHA512 auth

### DIFF
--- a/packages/v-protocol/src/messages.ts
+++ b/packages/v-protocol/src/messages.ts
@@ -22,6 +22,7 @@ export type MessageName =
   | 'copyOutResponse'
   | 'authenticationOk'
   | 'authenticationMD5Password'
+  | 'authenticationSHA512Password'
   | 'authenticationCleartextPassword'
   | 'authenticationSASL'
   | 'authenticationSASLContinue'
@@ -173,6 +174,11 @@ export class ParameterStatusMessage {
 export class AuthenticationMD5Password implements BackendMessage {
   public readonly name: MessageName = 'authenticationMD5Password'
   constructor(public readonly length: number, public readonly salt: Buffer) {}
+}
+
+export class AuthenticationSHA512Password implements BackendMessage {
+  public readonly name: MessageName = 'authenticationSHA512Password'
+  constructor(public readonly length: number, public readonly salt: Buffer, public readonly userSalt: Buffer) {}
 }
 
 export class BackendKeyDataMessage {

--- a/packages/v-protocol/src/parser.ts
+++ b/packages/v-protocol/src/parser.ts
@@ -329,10 +329,9 @@ export class Parser {
           return new AuthenticationMD5Password(length, salt)
         }
         break
-      case 65536:
-      case 66048:
-        // This will not currently be sent by the server as protocol version 3.5 is required for SHA512 auth
-        if(message.length == 32) {
+      case 65536: // AuthenticationHashPassword
+      case 66048: // AuthenticationHashSHA512Password
+        if(message.length === 32) {
           const salt = this.reader.bytes(4)
           const userSaltLen = this.reader.int32()
           const userSalt = this.reader.bytes(16)

--- a/packages/v-protocol/src/parser.ts
+++ b/packages/v-protocol/src/parser.ts
@@ -25,6 +25,7 @@ import {
   MessageName,
   AuthenticationMD5Password,
   NoticeMessage,
+  AuthenticationSHA512Password,
 } from './messages'
 import { BufferReader } from './buffer-reader'
 import assert from 'assert'
@@ -331,7 +332,13 @@ export class Parser {
       case 65536:
       case 66048:
         // This will not currently be sent by the server as protocol version 3.5 is required for SHA512 auth
-        console.log("Vertica server requested SHA512 Authentication - not supported")
+        if(message.length == 32) {
+          const salt = this.reader.bytes(4)
+          const userSaltLen = this.reader.int32()
+          const userSalt = this.reader.bytes(16)
+
+          return new AuthenticationSHA512Password(length, salt, userSalt)
+        }
         break
       case 9: // PasswordExpired
         return new DatabaseError('Could not authenticate: Password expired.', 0, 'error')

--- a/packages/vertica-nodejs/lib/client.js
+++ b/packages/vertica-nodejs/lib/client.js
@@ -263,6 +263,7 @@ class Client extends EventEmitter {
     con.on('authenticationCleartextPassword', this._handleAuthCleartextPassword.bind(this))
     // password request handling
     con.on('authenticationMD5Password', this._handleAuthMD5Password.bind(this))
+    con.on('authenticationSHA512Password', this._handleAuthSHA512Password.bind(this))
     // password request handling (SASL)
     con.on('authenticationSASL', this._handleAuthSASL.bind(this))
     con.on('authenticationSASLContinue', this._handleAuthSASLContinue.bind(this))
@@ -333,7 +334,7 @@ class Client extends EventEmitter {
          || parseInt(msg.parameterValue) > max_supported_version) {
 
           // error
-          throw new Error("Unsupported Protocol Version returned by Server. Connection Disallowed.");
+          //throw new Error("Unsupported Protocol Version returned by Server. Connection Disallowed.");
         }
         this.connectionParameters.protocol_version = parseInt(msg.ParameterValue) // likely to be the same, meaning this has no affect
         break;
@@ -351,6 +352,13 @@ class Client extends EventEmitter {
   _handleAuthMD5Password(msg) {
     this._checkPgPass(() => {
       const hashedPassword = utils.postgresMd5PasswordHash(this.user, this.password, msg.salt)
+      this.connection.password(hashedPassword)
+    })
+  }
+
+  _handleAuthSHA512Password(msg) {
+    this._checkPgPass(() => {
+      const hashedPassword = utils.postgresSha512PasswordHash(this.password, msg.salt, msg.userSalt)
       this.connection.password(hashedPassword)
     })
   }

--- a/packages/vertica-nodejs/lib/client.js
+++ b/packages/vertica-nodejs/lib/client.js
@@ -323,8 +323,8 @@ class Client extends EventEmitter {
   }
 
   _handleParameterStatus(msg) {
-    const min_supported_version = (3 << 16 | 0)         // 3.0 - newest protocol breaks functionality
-    const max_supported_version = this.protocol_version // for now we are enforcing 3.0
+    const min_supported_version = (3 << 16 | 5)         // 3.5
+    const max_supported_version = this.protocol_version // for now we are enforcing 3.5
     switch(msg.parameterName) {
       // right now we only care about the protocol_version
       // if we want to have the parameterStatus message update any other connection properties, add them here
@@ -335,7 +335,7 @@ class Client extends EventEmitter {
          || parseInt(msg.parameterValue) > max_supported_version) {
 
           // error
-          //throw new Error("Unsupported Protocol Version returned by Server. Connection Disallowed.");
+          throw new Error("Unsupported Protocol Version returned by Server. Connection Disallowed.");
         }
         this.connectionParameters.protocol_version = parseInt(msg.ParameterValue) // likely to be the same, meaning this has no affect
         break;

--- a/packages/vertica-nodejs/lib/utils.js
+++ b/packages/vertica-nodejs/lib/utils.js
@@ -168,11 +168,21 @@ const md5 = function (string) {
   return crypto.createHash('md5').update(string, 'utf-8').digest('hex')
 }
 
+const sha512 = function (string) {
+  return crypto.createHash('sha512').update(string, 'utf-8').digest('hex')
+}
+
 // See AuthenticationMD5Password at https://www.postgresql.org/docs/current/static/protocol-flow.html
 const postgresMd5PasswordHash = function (user, password, salt) {
   var inner = md5(password + user)
   var outer = md5(Buffer.concat([Buffer.from(inner), salt]))
   return 'md5' + outer
+}
+
+const postgresSha512PasswordHash = function (password, salt, userSalt) {
+  var inner = sha512(Buffer.concat([Buffer.from(password), userSalt]))
+  var outer = sha512(Buffer.concat([Buffer.from(inner), salt]))
+  return 'sha512' + outer
 }
 
 module.exports = {
@@ -184,4 +194,6 @@ module.exports = {
   normalizeQueryConfig,
   postgresMd5PasswordHash,
   md5,
+  postgresSha512PasswordHash,
+  sha512,
 }

--- a/packages/vertica-nodejs/test/unit/client/sha512-password-tests.js
+++ b/packages/vertica-nodejs/test/unit/client/sha512-password-tests.js
@@ -4,7 +4,7 @@ const BufferList = require('../../buffer-list')
 var utils = require('../../../lib/utils')
 
 // Test not currently working, waiting on in progress changes that fix the equivalent md5 test
-test('md5 authentication', function () {
+test('sha512 authentication', function () {
   var client = helper.createClient()
   client.password = '!'
   var salt = Buffer.from([1, 2, 3, 4])

--- a/packages/vertica-nodejs/test/unit/client/sha512-password-tests.js
+++ b/packages/vertica-nodejs/test/unit/client/sha512-password-tests.js
@@ -1,0 +1,22 @@
+'use strict'
+var helper = require('./test-helper')
+const BufferList = require('../../buffer-list')
+var utils = require('../../../lib/utils')
+
+// Test not currently working, waiting on in progress changes that fix the equivalent md5 test
+test('md5 authentication', function () {
+  var client = helper.createClient()
+  client.password = '!'
+  var salt = Buffer.from([1, 2, 3, 4])
+  var userSalt = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16])
+  client.connection.emit('authenticationSHA512Password', { salt: salt, userSalt: userSalt })
+
+  test('responds', function () {
+    assert.lengthIs(client.connection.stream.packets, 1)
+    test('should have correct encrypted data', function () {
+      var password = utils.postgresSha512PasswordHash(client.password, salt, userSalt)
+      // how do we want to test this?
+      assert.equalBuffers(client.connection.stream.packets[0], new BufferList().addCString(password).join(true, 'p'))
+    })
+  })
+})


### PR DESCRIPTION
- Adds handling for SHA512-related messages. 
- Adds a unit test, currently not working but in the same state as MD5 test that falls under another issue currently underway
