### PR TITLE
Added logic for parameterDescriptionMessage with 0 parameters

### DIFF
--- a/packages/v-protocol/src/parser.ts
+++ b/packages/v-protocol/src/parser.ts
@@ -290,11 +290,14 @@ export class Parser {
   private parseParameterDescriptionMessage(offset: number, length: number, bytes: Buffer) {
     this.reader.setBuffer(offset, bytes)
     const parameterCount = this.reader.int16()
+    const message = new ParameterDescriptionMessage(length, parameterCount)
+    if (parameterCount === 0) {
+      return message
+    }
     const nonNativeTypeCount = this.reader.int32() 
     if (nonNativeTypeCount > 0 ) {
       throw new Error("Non native types are not yet supported")
     }
-    const message = new ParameterDescriptionMessage(length, parameterCount)
     for (let i = 0; i < parameterCount; i++) {
       message.parameters[i] = this.parseParameter()
     }


### PR DESCRIPTION
Add correct parsing execution path for when a parameterStatusMessage has 0 parameters. In this scenario the server ends the message right after telling us there are 0 parameters. 