### PR TITLE
Updated keywords in package.json files to be vertica specific

### DIFF
--- a/packages/v-connection-string/package.json
+++ b/packages/v-connection-string/package.json
@@ -15,7 +15,7 @@
     "directory": "packages/v-connection-string"
   },
   "keywords": [
-    "pg",
+    "vertica",
     "connection",
     "string",
     "parse"

--- a/packages/v-pool/package.json
+++ b/packages/v-pool/package.json
@@ -15,8 +15,7 @@
     "directory": "packages/v-pool"
   },
   "keywords": [
-    "pg",
-    "postgres",
+    "vertica",
     "pool",
     "database"
   ],

--- a/packages/vertica-nodejs/package.json
+++ b/packages/vertica-nodejs/package.json
@@ -4,12 +4,8 @@
   "description": "Vertica client - pure javascript & libpq with the same API",
   "keywords": [
     "database",
-    "libpq",
-    "pg",
-    "postgre",
-    "postgres",
-    "postgresql",
-    "rdbms"
+    "rdbms",
+    "vertica"
   ],
   "homepage": "https://github.com/vertica/vertica-nodejs",
   "repository": {

--- a/packages/vertica-nodejs/package.json
+++ b/packages/vertica-nodejs/package.json
@@ -5,6 +5,7 @@
   "keywords": [
     "database",
     "rdbms",
+    "analytics",
     "vertica"
   ],
   "homepage": "https://github.com/vertica/vertica-nodejs",


### PR DESCRIPTION
First publish had keywords that were node-postgres specific.  Modified the package.json files to have vertica keywords.   I wonder if we should add other keywords too?