### PR TITLE
Prepare for release 0.9.0-pre.5

### DIFF
--- a/packages/publish_npm.sh
+++ b/packages/publish_npm.sh
@@ -44,11 +44,13 @@ read -p "Enter [yes] to publish [no] " shouldContinue
 # Therefore, any changes to this logic should be tested on linux and macos.
 shopt -s nocasematch
 if [[ ${shouldContinue} == "yes" ]]; then
+    echo "Building vertica-nodejs.."
+    yarn
     echo "Publishing to Node Package Manager.."
-    npm publish ./v-connection-string --tag MVP $dry_run_arg
-    npm publish ./v-pool --tag MVP  $dry_run_arg
-    npm publish ./v-protocol --tag MVP  $dry_run_arg
-    npm publish ./vertica-nodejs --tag MVP  $dry_run_arg
+    npm publish ./v-connection-string $dry_run_arg
+    npm publish ./v-pool $dry_run_arg
+    npm publish ./v-protocol $dry_run_arg
+    npm publish ./vertica-nodejs $dry_run_arg
 else
     echo "Publishing canceled"
 fi

--- a/packages/v-connection-string/package.json
+++ b/packages/v-connection-string/package.json
@@ -1,6 +1,6 @@
 {
   "name": "v-connection-string",
-  "version": "0.9.0-pre.4",
+  "version": "0.9.0-pre.5",
   "description": "Functions for dealing with a Vertica connection string",
   "main": "./index.js",
   "types": "./index.d.ts",

--- a/packages/v-pool/package.json
+++ b/packages/v-pool/package.json
@@ -1,6 +1,6 @@
 {
   "name": "v-pool",
-  "version": "0.9.0-pre.4",
+  "version": "0.9.0-pre.5",
   "description": "Connection pool for Vertica",
   "main": "index.js",
   "directories": {
@@ -36,6 +36,6 @@
     "pg-cursor": "^1.3.0"
   },
   "peerDependencies": {
-    "vertica-nodejs": "0.9.0-pre.4"
+    "vertica-nodejs": "0.9.0-pre.5"
   }
 }

--- a/packages/v-protocol/package.json
+++ b/packages/v-protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "v-protocol",
-  "version": "0.9.0-pre.4",
+  "version": "0.9.0-pre.5",
   "description": "The Vertica client/server binary protocol, implemented in TypeScript",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/vertica-nodejs/lib/client.js
+++ b/packages/vertica-nodejs/lib/client.js
@@ -25,8 +25,6 @@ var ConnectionParameters = require('./connection-parameters')
 var Query = require('./query')
 var defaults = require('./defaults')
 var Connection = require('./connection')
-const { parseCommandLine } = require('typescript')
-const { reject } = require('bluebird')
 
 class Client extends EventEmitter {
   constructor(config) {

--- a/packages/vertica-nodejs/package.json
+++ b/packages/vertica-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vertica-nodejs",
-  "version": "0.9.0-pre.4",
+  "version": "0.9.0-pre.5",
   "description": "Vertica client - pure javascript & libpq with the same API",
   "keywords": [
     "database",
@@ -28,9 +28,9 @@
   "dependencies": {
     "buffer-writer": "2.0.0",
     "packet-reader": "1.0.0",
-    "v-connection-string": "0.9.0-pre.4",
-    "v-pool": "0.9.0-pre.4",
-    "v-protocol": "0.9.0-pre.4",
+    "v-connection-string": "0.9.0-pre.5",
+    "v-pool": "0.9.0-pre.5",
+    "v-protocol": "0.9.0-pre.5",
     "pg-types": "^2.1.0",
     "pgpass": "1.x"
   },


### PR DESCRIPTION
This change updates the dependencies to version 0.9.0-pre.5. It also removes 2 problematic unused imports that were forcing user applications to add typescript and bluebird as dependencies. In addition, this change also updates the publish_npm.sh script.