### PR TITLE
Resolve rowDescription issue caused by parsing based on future protocol

### DIFF
--- a/packages/v-protocol/src/messages.ts
+++ b/packages/v-protocol/src/messages.ts
@@ -154,9 +154,15 @@ export class Field {
   constructor(
     public readonly name: string,
     public readonly tableID: bigint,
+    public readonly schemaName: string,
+    public readonly tableName: string,
     public readonly columnID: number,
+    //public readonly parentTypeID: number, //breadcrumb for complex types
+    //public readonly isNonNative: number,  //breadcrumb for non native types
     public readonly dataTypeID: number,
     public readonly dataTypeSize: number,
+    public readonly allowsNull: number,
+    public readonly isIdentity: number,
     public readonly dataTypeModifier: number,
     public readonly format: Mode
   ) {}
@@ -164,7 +170,7 @@ export class Field {
 
 export class RowDescriptionMessage {
   public readonly name: MessageName = 'rowDescription'
-  //public readonly nonNativeTypes: number; // leaving as breadcrumb for where to begin implementation of non native types
+  //public readonly nonNativeTypes: number; //breadcrumb for non native types
   public readonly fields: Field[]
   constructor(public readonly length: number, public readonly fieldCount: number) {
     this.fields = new Array(this.fieldCount)
@@ -182,7 +188,7 @@ export class Parameter {
 
 export class ParameterDescriptionMessage {
   public readonly name: MessageName = 'parameterDescription'
-  //public readonly nonNativeTyeps: number // leaving as breadcrumb for where to begin implementation of non native types
+  //public readonly nonNativeTyeps: number //breadcrumb for non native types
   public readonly parameters: Parameter[]
   constructor(public readonly length: number, public readonly parameterCount: number) {
     this.parameters = new Array(this.parameterCount)

--- a/packages/v-protocol/src/parser.ts
+++ b/packages/v-protocol/src/parser.ts
@@ -294,7 +294,7 @@ export class Parser {
     const schemaName = this.reader.cstring()
     const tableName = this.reader.cstring()
     const columnID = this.reader.int16()
-    const parentTypeID = this.reader.int16()
+    //const parentTypeID = this.reader.int16() // breadcrumb for complex types
     const isNonNative = this.reader.bytes(1)
     if (isNonNative[0] == 1) {
       throw new Error("Non native types are not yet supported")
@@ -305,7 +305,7 @@ export class Parser {
     const isIdentity = this.reader.int16()
     const dataTypeModifier = this.reader.int32()
     const mode = this.reader.int16() === 0 ? 'text' : 'binary'
-    return new Field(name, tableID, columnID, dataTypeID, dataTypeSize, dataTypeModifier, mode)
+    return new Field(name, tableID, schemaName, tableName, columnID, dataTypeID, dataTypeSize, allowsNull, isIdentity, dataTypeModifier, mode)
   }
 
   private parseParameterDescriptionMessage(offset: number, length: number, bytes: Buffer) {


### PR DESCRIPTION
There were issues with parsing rowDescription messages. We were trying to parse a field for the attribute number of the parent type for complex types. That doesn't apply here and shouldn't be parsed. In addition I added more information that was being parsed in the RowDescriptionMessage to the Field type. 