### PR TITLE
Updated copyright notices

### DIFF
--- a/packages/v-connection-string/README.md
+++ b/packages/v-connection-string/README.md
@@ -76,7 +76,8 @@ The causes and solutions to common errors can be found among the [Frequently Ask
 
 ## License
 
-<!-- Copyright (c) 2010-2020 Brian Carlson (brian.m.carlson@gmail.com) are we allowed to change this and if so do we have an open source email to use -->
+<!-- Original work Copyright (c) 2010-2020 Brian Carlson (brian.m.carlson@gmail.com) -->
+<!-- Modified work Copyright (c) 2022 Micro Focus or one of its affiliates.  -->
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/v-connection-string/index.js
+++ b/packages/v-connection-string/index.js
@@ -17,6 +17,10 @@
 var url = require('url')
 var fs = require('fs')
 
+//Parse method copied from https://github.com/brianc/node-postgres
+//Original work Copyright (c) 2010-2014 Brian Carlson (brian.m.carlson@gmail.com)
+//Modified work Copyright (c) 2022 Micro Focus or one of its affiliates.
+
 //parses a connection string
 function parse(str) {
   //unix socket

--- a/packages/v-pool/README.md
+++ b/packages/v-pool/README.md
@@ -66,7 +66,8 @@ The causes and solutions to common errors can be found among the [Frequently Ask
 
 ## License
 
-<!-- Copyright (c) 2010-2020 Brian Carlson (brian.m.carlson@gmail.com) are we allowed to change this and if so do we have an open source email to use -->
+<!-- Original work Copyright (c) 2010-2020 Brian Carlson (brian.m.carlson@gmail.com) -->
+<!-- Modified work Copyright (c) 2022 Micro Focus or one of its affiliates.  -->
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/v-protocol/README.md
+++ b/packages/v-protocol/README.md
@@ -64,7 +64,8 @@ The causes and solutions to common errors can be found among the [Frequently Ask
 
 ## License
 
-<!-- Copyright (c) 2010-2020 Brian Carlson (brian.m.carlson@gmail.com) are we allowed to change this and if so do we have an open source email to use -->
+<!-- Original work Copyright (c) 2010-2020 Brian Carlson (brian.m.carlson@gmail.com) -->
+<!-- Modified work Copyright (c) 2022 Micro Focus or one of its affiliates.  -->
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/vertica-nodejs/README.md
+++ b/packages/vertica-nodejs/README.md
@@ -64,7 +64,8 @@ The causes and solutions to common errors can be found among the [Frequently Ask
 
 ## License
 
-<!-- Copyright (c) 2010-2020 Brian Carlson (brian.m.carlson@gmail.com) are we allowed to change this and if so do we have an open source email to use -->
+<!-- Original work Copyright (c) 2010-2020 Brian Carlson (brian.m.carlson@gmail.com) -->
+<!-- Modified work Copyright (c) 2022 Micro Focus or one of its affiliates.  -->
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
After doing some research I found out how to correctly update the copyright for previously copyrighted code.  The node-postgres files were copyrighted by Brian Carlson.  Fortunately, there were relatively few original copyrights.   I checked this both in the vertica code and in the original node-postgres code.   As an additional safety check, I scanned all changes we have made to all .js files to make sure nothing had been removed.   With the exception of v-connection-string/index.js, all other copyrights are in the readme.md for each package.

The copyright notice changes from:
```
Copyright (c) 2010-2014 Brian Carlson ([brian.m.carlson@gmail.com](mailto:brian.m.carlson@gmail.com))
```
to:
```
Original work Copyright (c) 2010-2014 Brian Carlson ([brian.m.carlson@gmail.com](mailto:brian.m.carlson@gmail.com))
Modified work Copyright (c) 2022 Micro Focus or one of its affiliates.
```