### PR TITLE
Resolve rowDescription issue caused by parsing based on future protocol

### DIFF
--- a/packages/v-protocol/src/messages.ts
+++ b/packages/v-protocol/src/messages.ts
@@ -16,261 +16,261 @@
  * =============================================================================
  */
 
- export type Mode = 'text' | 'binary'
+export type Mode = 'text' | 'binary'
 
- export type MessageName =
-   | 'parseComplete'
-   | 'bindComplete'
-   | 'closeComplete'
-   | 'noData'
-   | 'portalSuspended'
-   | 'replicationStart'
-   | 'emptyQuery'
-   | 'copyDone'
-   | 'copyData'
-   | 'rowDescription'
-   | 'parameterDescription'
-   | 'parameterStatus'
-   | 'commandDescription'
-   | 'backendKeyData'
-   | 'notification'
-   | 'readyForQuery'
-   | 'commandComplete'
-   | 'dataRow'
-   | 'copyInResponse'
-   | 'copyOutResponse'
-   | 'authenticationOk'
-   | 'authenticationMD5Password'
-   | 'authenticationSHA512Password'
-   | 'authenticationCleartextPassword'
-   | 'error'
-   | 'notice'
- 
- export interface BackendMessage {
-   name: MessageName
-   length: number
- }
- 
- export const parseComplete: BackendMessage = {
-   name: 'parseComplete',
-   length: 5,
- }
- 
- export const bindComplete: BackendMessage = {
-   name: 'bindComplete',
-   length: 5,
- }
- 
- export const closeComplete: BackendMessage = {
-   name: 'closeComplete',
-   length: 5,
- }
- 
- export const noData: BackendMessage = {
-   name: 'noData',
-   length: 5,
- }
- 
- export const portalSuspended: BackendMessage = {
-   name: 'portalSuspended',
-   length: 5,
- }
- 
- export const replicationStart: BackendMessage = {
-   name: 'replicationStart',
-   length: 4,
- }
- 
- export const emptyQuery: BackendMessage = {
-   name: 'emptyQuery',
-   length: 4,
- }
- 
- export const copyDone: BackendMessage = {
-   name: 'copyDone',
-   length: 4,
- }
- 
- interface NoticeOrError {
-   message: string | undefined
-   severity: string | undefined
-   code: string | undefined
-   detail: string | undefined
-   hint: string | undefined
-   position: string | undefined
-   internalPosition: string | undefined
-   internalQuery: string | undefined
-   where: string | undefined
-   schema: string | undefined
-   table: string | undefined
-   column: string | undefined
-   dataType: string | undefined
-   constraint: string | undefined
-   file: string | undefined
-   line: string | undefined
-   routine: string | undefined
- }
- 
- export class DatabaseError extends Error implements NoticeOrError {
-   public severity: string | undefined
-   public code: string | undefined
-   public detail: string | undefined
-   public hint: string | undefined
-   public position: string | undefined
-   public internalPosition: string | undefined
-   public internalQuery: string | undefined
-   public where: string | undefined
-   public schema: string | undefined
-   public table: string | undefined
-   public column: string | undefined
-   public dataType: string | undefined
-   public constraint: string | undefined
-   public file: string | undefined
-   public line: string | undefined
-   public routine: string | undefined
-   constructor(message: string, public readonly length: number, public readonly name: MessageName) {
-     super(message)
-   }
- }
- 
- export class CopyDataMessage {
-   public readonly name = 'copyData'
-   constructor(public readonly length: number, public readonly chunk: Buffer) {}
- }
- 
- export class CopyResponse {
-   public readonly columnTypes: number[]
-   constructor(
-     public readonly length: number,
-     public readonly name: MessageName,
-     public readonly binary: boolean,
-     columnCount: number
-   ) {
-     this.columnTypes = new Array(columnCount)
-   }
- }
- 
- export class Field {
-   constructor(
-     public readonly name: string,
-     public readonly tableID: bigint,
-     public readonly schemaName: string,
-     public readonly tableName: string,
-     public readonly columnID: number,
-     //public readonly parentTypeID: number, //breadcrumb for complex types
-     //public readonly isNonNative: number,  //breadcrumb for non native types
-     public readonly dataTypeID: number,
-     public readonly dataTypeSize: number,
-     public readonly allowsNull: number,
-     public readonly isIdentity: number,
-     public readonly dataTypeModifier: number,
-     public readonly format: Mode
-   ) {}
- }
- 
- export class RowDescriptionMessage {
-   public readonly name: MessageName = 'rowDescription'
-   //public readonly nonNativeTypes: number; //breadcrumb for non native types
-   public readonly fields: Field[]
-   constructor(public readonly length: number, public readonly fieldCount: number) {
-     this.fields = new Array(this.fieldCount)
-   }
- }
- 
- export class Parameter {
-   constructor (
-     public readonly isNonNative: boolean,
-     public readonly oid: number, // for non native types, the oid becomes the index into the type mapping pool
-     public readonly typemod: number,
-     public readonly hasNotNullConstraint: number
-   ) {}
- }
- 
- export class ParameterDescriptionMessage {
-   public readonly name: MessageName = 'parameterDescription'
-   //public readonly nonNativeTyeps: number //breadcrumb for non native types
-   public readonly parameters: Parameter[]
-   constructor(public readonly length: number, public readonly parameterCount: number) {
-     this.parameters = new Array(this.parameterCount)
-   }
- }
- 
- export class ParameterStatusMessage {
-   public readonly name: MessageName = 'parameterStatus'
-   constructor(
-     public readonly length: number,
-     public readonly parameterName: string,
-     public readonly parameterValue: string
-   ) {}
- }
- 
- export class CommandDescriptionMessage {
-   public readonly name: MessageName = 'commandDescription'
-   constructor ( public readonly length: number, public readonly tag: string, 
-                 public readonly convertedToCopy: number, public readonly convertedStatement: string) {}
- }
- 
- export class AuthenticationMD5Password implements BackendMessage {
-   public readonly name: MessageName = 'authenticationMD5Password'
-   constructor(public readonly length: number, public readonly salt: Buffer) {}
- }
- 
- export class AuthenticationSHA512Password implements BackendMessage {
-   public readonly name: MessageName = 'authenticationSHA512Password'
-   constructor(public readonly length: number, public readonly salt: Buffer, public readonly userSalt: Buffer) {}
- }
- 
- export class BackendKeyDataMessage {
-   public readonly name: MessageName = 'backendKeyData'
-   constructor(public readonly length: number, public readonly processID: number, public readonly secretKey: number) {}
- }
- 
- export class NotificationResponseMessage {
-   public readonly name: MessageName = 'notification'
-   constructor(
-     public readonly length: number,
-     public readonly processId: number,
-     public readonly channel: string,
-     public readonly payload: string
-   ) {}
- }
- 
- export class ReadyForQueryMessage {
-   public readonly name: MessageName = 'readyForQuery'
-   constructor(public readonly length: number, public readonly status: string) {}
- }
- 
- export class CommandCompleteMessage {
-   public readonly name: MessageName = 'commandComplete'
-   constructor(public readonly length: number, public readonly text: string) {}
- }
- 
- export class DataRowMessage {
-   public readonly fieldCount: number
-   public readonly name: MessageName = 'dataRow'
-   constructor(public length: number, public fields: any[]) {
-     this.fieldCount = fields.length
-   }
- }
- 
- export class NoticeMessage implements BackendMessage, NoticeOrError {
-   constructor(public readonly length: number, public readonly message: string | undefined) {}
-   public readonly name = 'notice'
-   public severity: string | undefined
-   public code: string | undefined
-   public detail: string | undefined
-   public hint: string | undefined
-   public position: string | undefined
-   public internalPosition: string | undefined
-   public internalQuery: string | undefined
-   public where: string | undefined
-   public schema: string | undefined
-   public table: string | undefined
-   public column: string | undefined
-   public dataType: string | undefined
-   public constraint: string | undefined
-   public file: string | undefined
-   public line: string | undefined
-   public routine: string | undefined
- }
+export type MessageName =
+  | 'parseComplete'
+  | 'bindComplete'
+  | 'closeComplete'
+  | 'noData'
+  | 'portalSuspended'
+  | 'replicationStart'
+  | 'emptyQuery'
+  | 'copyDone'
+  | 'copyData'
+  | 'rowDescription'
+  | 'parameterDescription'
+  | 'parameterStatus'
+  | 'commandDescription'
+  | 'backendKeyData'
+  | 'notification'
+  | 'readyForQuery'
+  | 'commandComplete'
+  | 'dataRow'
+  | 'copyInResponse'
+  | 'copyOutResponse'
+  | 'authenticationOk'
+  | 'authenticationMD5Password'
+  | 'authenticationSHA512Password'
+  | 'authenticationCleartextPassword'
+  | 'error'
+  | 'notice'
+
+export interface BackendMessage {
+  name: MessageName
+  length: number
+}
+
+export const parseComplete: BackendMessage = {
+  name: 'parseComplete',
+  length: 5,
+}
+
+export const bindComplete: BackendMessage = {
+  name: 'bindComplete',
+  length: 5,
+}
+
+export const closeComplete: BackendMessage = {
+  name: 'closeComplete',
+  length: 5,
+}
+
+export const noData: BackendMessage = {
+  name: 'noData',
+  length: 5,
+}
+
+export const portalSuspended: BackendMessage = {
+  name: 'portalSuspended',
+  length: 5,
+}
+
+export const replicationStart: BackendMessage = {
+  name: 'replicationStart',
+  length: 4,
+}
+
+export const emptyQuery: BackendMessage = {
+  name: 'emptyQuery',
+  length: 4,
+}
+
+export const copyDone: BackendMessage = {
+  name: 'copyDone',
+  length: 4,
+}
+
+interface NoticeOrError {
+  message: string | undefined
+  severity: string | undefined
+  code: string | undefined
+  detail: string | undefined
+  hint: string | undefined
+  position: string | undefined
+  internalPosition: string | undefined
+  internalQuery: string | undefined
+  where: string | undefined
+  schema: string | undefined
+  table: string | undefined
+  column: string | undefined
+  dataType: string | undefined
+  constraint: string | undefined
+  file: string | undefined
+  line: string | undefined
+  routine: string | undefined
+}
+
+export class DatabaseError extends Error implements NoticeOrError {
+  public severity: string | undefined
+  public code: string | undefined
+  public detail: string | undefined
+  public hint: string | undefined
+  public position: string | undefined
+  public internalPosition: string | undefined
+  public internalQuery: string | undefined
+  public where: string | undefined
+  public schema: string | undefined
+  public table: string | undefined
+  public column: string | undefined
+  public dataType: string | undefined
+  public constraint: string | undefined
+  public file: string | undefined
+  public line: string | undefined
+  public routine: string | undefined
+  constructor(message: string, public readonly length: number, public readonly name: MessageName) {
+    super(message)
+  }
+}
+
+export class CopyDataMessage {
+  public readonly name = 'copyData'
+  constructor(public readonly length: number, public readonly chunk: Buffer) {}
+}
+
+export class CopyResponse {
+  public readonly columnTypes: number[]
+  constructor(
+    public readonly length: number,
+    public readonly name: MessageName,
+    public readonly binary: boolean,
+    columnCount: number
+  ) {
+    this.columnTypes = new Array(columnCount)
+  }
+}
+
+export class Field {
+  constructor(
+    public readonly name: string,
+    public readonly tableID: bigint,
+    public readonly schemaName: string,
+    public readonly tableName: string,
+    public readonly columnID: number,
+    //public readonly parentTypeID: number, //breadcrumb for complex types
+    //public readonly isNonNative: number,  //breadcrumb for non native types
+    public readonly dataTypeID: number,
+    public readonly dataTypeSize: number,
+    public readonly allowsNull: number,
+    public readonly isIdentity: number,
+    public readonly dataTypeModifier: number,
+    public readonly format: Mode
+  ) {}
+}
+
+export class RowDescriptionMessage {
+  public readonly name: MessageName = 'rowDescription'
+  //public readonly nonNativeTypes: number; //breadcrumb for non native types
+  public readonly fields: Field[]
+  constructor(public readonly length: number, public readonly fieldCount: number) {
+    this.fields = new Array(this.fieldCount)
+  }
+}
+
+export class Parameter {
+  constructor (
+    public readonly isNonNative: boolean,
+    public readonly oid: number, // for non native types, the oid becomes the index into the type mapping pool
+    public readonly typemod: number,
+    public readonly hasNotNullConstraint: number
+  ) {}
+}
+
+export class ParameterDescriptionMessage {
+  public readonly name: MessageName = 'parameterDescription'
+  //public readonly nonNativeTyeps: number //breadcrumb for non native types
+  public readonly parameters: Parameter[]
+  constructor(public readonly length: number, public readonly parameterCount: number) {
+    this.parameters = new Array(this.parameterCount)
+  }
+}
+
+export class ParameterStatusMessage {
+  public readonly name: MessageName = 'parameterStatus'
+  constructor(
+    public readonly length: number,
+    public readonly parameterName: string,
+    public readonly parameterValue: string
+  ) {}
+}
+
+export class CommandDescriptionMessage {
+  public readonly name: MessageName = 'commandDescription'
+  constructor ( public readonly length: number, public readonly tag: string, 
+                public readonly convertedToCopy: number, public readonly convertedStatement: string) {}
+}
+
+export class AuthenticationMD5Password implements BackendMessage {
+  public readonly name: MessageName = 'authenticationMD5Password'
+  constructor(public readonly length: number, public readonly salt: Buffer) {}
+}
+
+export class AuthenticationSHA512Password implements BackendMessage {
+  public readonly name: MessageName = 'authenticationSHA512Password'
+  constructor(public readonly length: number, public readonly salt: Buffer, public readonly userSalt: Buffer) {}
+}
+
+export class BackendKeyDataMessage {
+  public readonly name: MessageName = 'backendKeyData'
+  constructor(public readonly length: number, public readonly processID: number, public readonly secretKey: number) {}
+}
+
+export class NotificationResponseMessage {
+  public readonly name: MessageName = 'notification'
+  constructor(
+    public readonly length: number,
+    public readonly processId: number,
+    public readonly channel: string,
+    public readonly payload: string
+  ) {}
+}
+
+export class ReadyForQueryMessage {
+  public readonly name: MessageName = 'readyForQuery'
+  constructor(public readonly length: number, public readonly status: string) {}
+}
+
+export class CommandCompleteMessage {
+  public readonly name: MessageName = 'commandComplete'
+  constructor(public readonly length: number, public readonly text: string) {}
+}
+
+export class DataRowMessage {
+  public readonly fieldCount: number
+  public readonly name: MessageName = 'dataRow'
+  constructor(public length: number, public fields: any[]) {
+    this.fieldCount = fields.length
+  }
+}
+
+export class NoticeMessage implements BackendMessage, NoticeOrError {
+  constructor(public readonly length: number, public readonly message: string | undefined) {}
+  public readonly name = 'notice'
+  public severity: string | undefined
+  public code: string | undefined
+  public detail: string | undefined
+  public hint: string | undefined
+  public position: string | undefined
+  public internalPosition: string | undefined
+  public internalQuery: string | undefined
+  public where: string | undefined
+  public schema: string | undefined
+  public table: string | undefined
+  public column: string | undefined
+  public dataType: string | undefined
+  public constraint: string | undefined
+  public file: string | undefined
+  public line: string | undefined
+  public routine: string | undefined
+}
  

--- a/packages/v-protocol/src/messages.ts
+++ b/packages/v-protocol/src/messages.ts
@@ -16,254 +16,261 @@
  * =============================================================================
  */
 
-export type Mode = 'text' | 'binary'
+ export type Mode = 'text' | 'binary'
 
-export type MessageName =
-  | 'parseComplete'
-  | 'bindComplete'
-  | 'closeComplete'
-  | 'noData'
-  | 'portalSuspended'
-  | 'replicationStart'
-  | 'emptyQuery'
-  | 'copyDone'
-  | 'copyData'
-  | 'rowDescription'
-  | 'parameterDescription'
-  | 'parameterStatus'
-  | 'commandDescription'
-  | 'backendKeyData'
-  | 'notification'
-  | 'readyForQuery'
-  | 'commandComplete'
-  | 'dataRow'
-  | 'copyInResponse'
-  | 'copyOutResponse'
-  | 'authenticationOk'
-  | 'authenticationMD5Password'
-  | 'authenticationSHA512Password'
-  | 'authenticationCleartextPassword'
-  | 'error'
-  | 'notice'
-
-export interface BackendMessage {
-  name: MessageName
-  length: number
-}
-
-export const parseComplete: BackendMessage = {
-  name: 'parseComplete',
-  length: 5,
-}
-
-export const bindComplete: BackendMessage = {
-  name: 'bindComplete',
-  length: 5,
-}
-
-export const closeComplete: BackendMessage = {
-  name: 'closeComplete',
-  length: 5,
-}
-
-export const noData: BackendMessage = {
-  name: 'noData',
-  length: 5,
-}
-
-export const portalSuspended: BackendMessage = {
-  name: 'portalSuspended',
-  length: 5,
-}
-
-export const replicationStart: BackendMessage = {
-  name: 'replicationStart',
-  length: 4,
-}
-
-export const emptyQuery: BackendMessage = {
-  name: 'emptyQuery',
-  length: 4,
-}
-
-export const copyDone: BackendMessage = {
-  name: 'copyDone',
-  length: 4,
-}
-
-interface NoticeOrError {
-  message: string | undefined
-  severity: string | undefined
-  code: string | undefined
-  detail: string | undefined
-  hint: string | undefined
-  position: string | undefined
-  internalPosition: string | undefined
-  internalQuery: string | undefined
-  where: string | undefined
-  schema: string | undefined
-  table: string | undefined
-  column: string | undefined
-  dataType: string | undefined
-  constraint: string | undefined
-  file: string | undefined
-  line: string | undefined
-  routine: string | undefined
-}
-
-export class DatabaseError extends Error implements NoticeOrError {
-  public severity: string | undefined
-  public code: string | undefined
-  public detail: string | undefined
-  public hint: string | undefined
-  public position: string | undefined
-  public internalPosition: string | undefined
-  public internalQuery: string | undefined
-  public where: string | undefined
-  public schema: string | undefined
-  public table: string | undefined
-  public column: string | undefined
-  public dataType: string | undefined
-  public constraint: string | undefined
-  public file: string | undefined
-  public line: string | undefined
-  public routine: string | undefined
-  constructor(message: string, public readonly length: number, public readonly name: MessageName) {
-    super(message)
-  }
-}
-
-export class CopyDataMessage {
-  public readonly name = 'copyData'
-  constructor(public readonly length: number, public readonly chunk: Buffer) {}
-}
-
-export class CopyResponse {
-  public readonly columnTypes: number[]
-  constructor(
-    public readonly length: number,
-    public readonly name: MessageName,
-    public readonly binary: boolean,
-    columnCount: number
-  ) {
-    this.columnTypes = new Array(columnCount)
-  }
-}
-
-export class Field {
-  constructor(
-    public readonly name: string,
-    public readonly tableID: bigint,
-    public readonly columnID: number,
-    public readonly dataTypeID: number,
-    public readonly dataTypeSize: number,
-    public readonly dataTypeModifier: number,
-    public readonly format: Mode
-  ) {}
-}
-
-export class RowDescriptionMessage {
-  public readonly name: MessageName = 'rowDescription'
-  //public readonly nonNativeTypes: number; // leaving as breadcrumb for where to begin implementation of non native types
-  public readonly fields: Field[]
-  constructor(public readonly length: number, public readonly fieldCount: number) {
-    this.fields = new Array(this.fieldCount)
-  }
-}
-
-export class Parameter {
-  constructor (
-    public readonly isNonNative: boolean,
-    public readonly oid: number, // for non native types, the oid becomes the index into the type mapping pool
-    public readonly typemod: number,
-    public readonly hasNotNullConstraint: number
-  ) {}
-}
-
-export class ParameterDescriptionMessage {
-  public readonly name: MessageName = 'parameterDescription'
-  //public readonly nonNativeTyeps: number // leaving as breadcrumb for where to begin implementation of non native types
-  public readonly parameters: Parameter[]
-  constructor(public readonly length: number, public readonly parameterCount: number) {
-    this.parameters = new Array(this.parameterCount)
-  }
-}
-
-export class ParameterStatusMessage {
-  public readonly name: MessageName = 'parameterStatus'
-  constructor(
-    public readonly length: number,
-    public readonly parameterName: string,
-    public readonly parameterValue: string
-  ) {}
-}
-
-export class CommandDescriptionMessage {
-  public readonly name: MessageName = 'commandDescription'
-  constructor ( public readonly length: number, public readonly tag: string, 
-                public readonly convertedToCopy: number, public readonly convertedStatement: string) {}
-}
-
-export class AuthenticationMD5Password implements BackendMessage {
-  public readonly name: MessageName = 'authenticationMD5Password'
-  constructor(public readonly length: number, public readonly salt: Buffer) {}
-}
-
-export class AuthenticationSHA512Password implements BackendMessage {
-  public readonly name: MessageName = 'authenticationSHA512Password'
-  constructor(public readonly length: number, public readonly salt: Buffer, public readonly userSalt: Buffer) {}
-}
-
-export class BackendKeyDataMessage {
-  public readonly name: MessageName = 'backendKeyData'
-  constructor(public readonly length: number, public readonly processID: number, public readonly secretKey: number) {}
-}
-
-export class NotificationResponseMessage {
-  public readonly name: MessageName = 'notification'
-  constructor(
-    public readonly length: number,
-    public readonly processId: number,
-    public readonly channel: string,
-    public readonly payload: string
-  ) {}
-}
-
-export class ReadyForQueryMessage {
-  public readonly name: MessageName = 'readyForQuery'
-  constructor(public readonly length: number, public readonly status: string) {}
-}
-
-export class CommandCompleteMessage {
-  public readonly name: MessageName = 'commandComplete'
-  constructor(public readonly length: number, public readonly text: string) {}
-}
-
-export class DataRowMessage {
-  public readonly fieldCount: number
-  public readonly name: MessageName = 'dataRow'
-  constructor(public length: number, public fields: any[]) {
-    this.fieldCount = fields.length
-  }
-}
-
-export class NoticeMessage implements BackendMessage, NoticeOrError {
-  constructor(public readonly length: number, public readonly message: string | undefined) {}
-  public readonly name = 'notice'
-  public severity: string | undefined
-  public code: string | undefined
-  public detail: string | undefined
-  public hint: string | undefined
-  public position: string | undefined
-  public internalPosition: string | undefined
-  public internalQuery: string | undefined
-  public where: string | undefined
-  public schema: string | undefined
-  public table: string | undefined
-  public column: string | undefined
-  public dataType: string | undefined
-  public constraint: string | undefined
-  public file: string | undefined
-  public line: string | undefined
-  public routine: string | undefined
-}
+ export type MessageName =
+   | 'parseComplete'
+   | 'bindComplete'
+   | 'closeComplete'
+   | 'noData'
+   | 'portalSuspended'
+   | 'replicationStart'
+   | 'emptyQuery'
+   | 'copyDone'
+   | 'copyData'
+   | 'rowDescription'
+   | 'parameterDescription'
+   | 'parameterStatus'
+   | 'commandDescription'
+   | 'backendKeyData'
+   | 'notification'
+   | 'readyForQuery'
+   | 'commandComplete'
+   | 'dataRow'
+   | 'copyInResponse'
+   | 'copyOutResponse'
+   | 'authenticationOk'
+   | 'authenticationMD5Password'
+   | 'authenticationSHA512Password'
+   | 'authenticationCleartextPassword'
+   | 'error'
+   | 'notice'
+ 
+ export interface BackendMessage {
+   name: MessageName
+   length: number
+ }
+ 
+ export const parseComplete: BackendMessage = {
+   name: 'parseComplete',
+   length: 5,
+ }
+ 
+ export const bindComplete: BackendMessage = {
+   name: 'bindComplete',
+   length: 5,
+ }
+ 
+ export const closeComplete: BackendMessage = {
+   name: 'closeComplete',
+   length: 5,
+ }
+ 
+ export const noData: BackendMessage = {
+   name: 'noData',
+   length: 5,
+ }
+ 
+ export const portalSuspended: BackendMessage = {
+   name: 'portalSuspended',
+   length: 5,
+ }
+ 
+ export const replicationStart: BackendMessage = {
+   name: 'replicationStart',
+   length: 4,
+ }
+ 
+ export const emptyQuery: BackendMessage = {
+   name: 'emptyQuery',
+   length: 4,
+ }
+ 
+ export const copyDone: BackendMessage = {
+   name: 'copyDone',
+   length: 4,
+ }
+ 
+ interface NoticeOrError {
+   message: string | undefined
+   severity: string | undefined
+   code: string | undefined
+   detail: string | undefined
+   hint: string | undefined
+   position: string | undefined
+   internalPosition: string | undefined
+   internalQuery: string | undefined
+   where: string | undefined
+   schema: string | undefined
+   table: string | undefined
+   column: string | undefined
+   dataType: string | undefined
+   constraint: string | undefined
+   file: string | undefined
+   line: string | undefined
+   routine: string | undefined
+ }
+ 
+ export class DatabaseError extends Error implements NoticeOrError {
+   public severity: string | undefined
+   public code: string | undefined
+   public detail: string | undefined
+   public hint: string | undefined
+   public position: string | undefined
+   public internalPosition: string | undefined
+   public internalQuery: string | undefined
+   public where: string | undefined
+   public schema: string | undefined
+   public table: string | undefined
+   public column: string | undefined
+   public dataType: string | undefined
+   public constraint: string | undefined
+   public file: string | undefined
+   public line: string | undefined
+   public routine: string | undefined
+   constructor(message: string, public readonly length: number, public readonly name: MessageName) {
+     super(message)
+   }
+ }
+ 
+ export class CopyDataMessage {
+   public readonly name = 'copyData'
+   constructor(public readonly length: number, public readonly chunk: Buffer) {}
+ }
+ 
+ export class CopyResponse {
+   public readonly columnTypes: number[]
+   constructor(
+     public readonly length: number,
+     public readonly name: MessageName,
+     public readonly binary: boolean,
+     columnCount: number
+   ) {
+     this.columnTypes = new Array(columnCount)
+   }
+ }
+ 
+ export class Field {
+   constructor(
+     public readonly name: string,
+     public readonly tableID: bigint,
+     public readonly schemaName: string,
+     public readonly tableName: string,
+     public readonly columnID: number,
+     //public readonly parentTypeID: number, //breadcrumb for complex types
+     //public readonly isNonNative: number,  //breadcrumb for non native types
+     public readonly dataTypeID: number,
+     public readonly dataTypeSize: number,
+     public readonly allowsNull: number,
+     public readonly isIdentity: number,
+     public readonly dataTypeModifier: number,
+     public readonly format: Mode
+   ) {}
+ }
+ 
+ export class RowDescriptionMessage {
+   public readonly name: MessageName = 'rowDescription'
+   //public readonly nonNativeTypes: number; //breadcrumb for non native types
+   public readonly fields: Field[]
+   constructor(public readonly length: number, public readonly fieldCount: number) {
+     this.fields = new Array(this.fieldCount)
+   }
+ }
+ 
+ export class Parameter {
+   constructor (
+     public readonly isNonNative: boolean,
+     public readonly oid: number, // for non native types, the oid becomes the index into the type mapping pool
+     public readonly typemod: number,
+     public readonly hasNotNullConstraint: number
+   ) {}
+ }
+ 
+ export class ParameterDescriptionMessage {
+   public readonly name: MessageName = 'parameterDescription'
+   //public readonly nonNativeTyeps: number //breadcrumb for non native types
+   public readonly parameters: Parameter[]
+   constructor(public readonly length: number, public readonly parameterCount: number) {
+     this.parameters = new Array(this.parameterCount)
+   }
+ }
+ 
+ export class ParameterStatusMessage {
+   public readonly name: MessageName = 'parameterStatus'
+   constructor(
+     public readonly length: number,
+     public readonly parameterName: string,
+     public readonly parameterValue: string
+   ) {}
+ }
+ 
+ export class CommandDescriptionMessage {
+   public readonly name: MessageName = 'commandDescription'
+   constructor ( public readonly length: number, public readonly tag: string, 
+                 public readonly convertedToCopy: number, public readonly convertedStatement: string) {}
+ }
+ 
+ export class AuthenticationMD5Password implements BackendMessage {
+   public readonly name: MessageName = 'authenticationMD5Password'
+   constructor(public readonly length: number, public readonly salt: Buffer) {}
+ }
+ 
+ export class AuthenticationSHA512Password implements BackendMessage {
+   public readonly name: MessageName = 'authenticationSHA512Password'
+   constructor(public readonly length: number, public readonly salt: Buffer, public readonly userSalt: Buffer) {}
+ }
+ 
+ export class BackendKeyDataMessage {
+   public readonly name: MessageName = 'backendKeyData'
+   constructor(public readonly length: number, public readonly processID: number, public readonly secretKey: number) {}
+ }
+ 
+ export class NotificationResponseMessage {
+   public readonly name: MessageName = 'notification'
+   constructor(
+     public readonly length: number,
+     public readonly processId: number,
+     public readonly channel: string,
+     public readonly payload: string
+   ) {}
+ }
+ 
+ export class ReadyForQueryMessage {
+   public readonly name: MessageName = 'readyForQuery'
+   constructor(public readonly length: number, public readonly status: string) {}
+ }
+ 
+ export class CommandCompleteMessage {
+   public readonly name: MessageName = 'commandComplete'
+   constructor(public readonly length: number, public readonly text: string) {}
+ }
+ 
+ export class DataRowMessage {
+   public readonly fieldCount: number
+   public readonly name: MessageName = 'dataRow'
+   constructor(public length: number, public fields: any[]) {
+     this.fieldCount = fields.length
+   }
+ }
+ 
+ export class NoticeMessage implements BackendMessage, NoticeOrError {
+   constructor(public readonly length: number, public readonly message: string | undefined) {}
+   public readonly name = 'notice'
+   public severity: string | undefined
+   public code: string | undefined
+   public detail: string | undefined
+   public hint: string | undefined
+   public position: string | undefined
+   public internalPosition: string | undefined
+   public internalQuery: string | undefined
+   public where: string | undefined
+   public schema: string | undefined
+   public table: string | undefined
+   public column: string | undefined
+   public dataType: string | undefined
+   public constraint: string | undefined
+   public file: string | undefined
+   public line: string | undefined
+   public routine: string | undefined
+ }
+ 

--- a/packages/v-protocol/src/messages.ts
+++ b/packages/v-protocol/src/messages.ts
@@ -273,4 +273,3 @@ export class NoticeMessage implements BackendMessage, NoticeOrError {
   public line: string | undefined
   public routine: string | undefined
 }
- 

--- a/packages/v-protocol/src/parser.ts
+++ b/packages/v-protocol/src/parser.ts
@@ -16,433 +16,434 @@
  * =============================================================================
  */
 
-import { TransformOptions } from 'stream'
-import {
-  Mode,
-  bindComplete,
-  parseComplete,
-  closeComplete,
-  noData,
-  portalSuspended,
-  copyDone,
-  replicationStart,
-  emptyQuery,
-  ReadyForQueryMessage,
-  CommandCompleteMessage,
-  CopyDataMessage,
-  CopyResponse,
-  NotificationResponseMessage,
-  RowDescriptionMessage,
-  ParameterDescriptionMessage,
-  Parameter,
-  CommandDescriptionMessage,
-  Field,
-  DataRowMessage,
-  ParameterStatusMessage,
-  BackendKeyDataMessage,
-  DatabaseError,
-  BackendMessage,
-  MessageName,
-  AuthenticationMD5Password,
-  NoticeMessage,
-  AuthenticationSHA512Password,
-} from './messages'
-import { BufferReader } from './buffer-reader'
-import assert from 'assert'
-
-// every message is prefixed with a single bye
-const CODE_LENGTH = 1
-// every message has an int32 length which includes itself but does
-// NOT include the code in the length
-const LEN_LENGTH = 4
-
-const HEADER_LENGTH = CODE_LENGTH + LEN_LENGTH
-
-export type Packet = {
-  code: number
-  packet: Buffer
-}
-
-const emptyBuffer = Buffer.allocUnsafe(0)
-
-type StreamOptions = TransformOptions & {
-  mode: Mode
-}
-
-const enum MessageCodes {
-  DataRow = 0x44, // D
-  ParseComplete = 0x31, // 1
-  BindComplete = 0x32, // 2
-  CloseComplete = 0x33, // 3
-  CommandComplete = 0x43, // C
-  ReadyForQuery = 0x5a, // Z
-  NoData = 0x6e, // n
-  NotificationResponse = 0x41, // A
-  AuthenticationResponse = 0x52, // R
-  ParameterStatus = 0x53, // S
-  BackendKeyData = 0x4b, // K
-  ErrorMessage = 0x45, // E
-  NoticeMessage = 0x4e, // N
-  RowDescriptionMessage = 0x54, // T
-  ParameterDescriptionMessage = 0x74, // t
-  CommandDescriptionMessage = 0x6d, // m
-  PortalSuspended = 0x73, // s
-  ReplicationStart = 0x57, // W
-  EmptyQuery = 0x49, // I
-  CopyIn = 0x47, // G
-  CopyOut = 0x48, // H
-  CopyDone = 0x63, // c
-  CopyData = 0x64, // d
-}
-
-export type MessageCallback = (msg: BackendMessage) => void
-
-export class Parser {
-  private buffer: Buffer = emptyBuffer
-  private bufferLength: number = 0
-  private bufferOffset: number = 0
-  private reader = new BufferReader()
-  private mode: Mode
-
-  constructor(opts?: StreamOptions) {
-    if (opts?.mode === 'binary') {
-      throw new Error('Binary mode not supported yet')
-    }
-    this.mode = opts?.mode || 'text'
-  }
-
-  public parse(buffer: Buffer, callback: MessageCallback) {
-    this.mergeBuffer(buffer)
-    const bufferFullLength = this.bufferOffset + this.bufferLength
-    let offset = this.bufferOffset
-    while (offset + HEADER_LENGTH <= bufferFullLength) {
-      // code is 1 byte long - it identifies the message type
-      const code = this.buffer[offset]
-      // length is 1 Uint32BE - it is the length of the message EXCLUDING the code
-      const length = this.buffer.readUInt32BE(offset + CODE_LENGTH)
-      const fullMessageLength = CODE_LENGTH + length
-      if (fullMessageLength + offset <= bufferFullLength) {
-        const message = this.handlePacket(offset + HEADER_LENGTH, code, length, this.buffer)
-        callback(message)
-        offset += fullMessageLength
-      } else {
-        break
-      }
-    }
-    if (offset === bufferFullLength) {
-      // No more use for the buffer
-      this.buffer = emptyBuffer
-      this.bufferLength = 0
-      this.bufferOffset = 0
-    } else {
-      // Adjust the cursors of remainingBuffer
-      this.bufferLength = bufferFullLength - offset
-      this.bufferOffset = offset
-    }
-  }
-
-  private mergeBuffer(buffer: Buffer): void {
-    if (this.bufferLength > 0) {
-      const newLength = this.bufferLength + buffer.byteLength
-      const newFullLength = newLength + this.bufferOffset
-      if (newFullLength > this.buffer.byteLength) {
-        // We can't concat the new buffer with the remaining one
-        let newBuffer: Buffer
-        if (newLength <= this.buffer.byteLength && this.bufferOffset >= this.bufferLength) {
-          // We can move the relevant part to the beginning of the buffer instead of allocating a new buffer
-          newBuffer = this.buffer
-        } else {
-          // Allocate a new larger buffer
-          let newBufferLength = this.buffer.byteLength * 2
-          while (newLength >= newBufferLength) {
-            newBufferLength *= 2
-          }
-          newBuffer = Buffer.allocUnsafe(newBufferLength)
-        }
-        // Move the remaining buffer to the new one
-        this.buffer.copy(newBuffer, 0, this.bufferOffset, this.bufferOffset + this.bufferLength)
-        this.buffer = newBuffer
-        this.bufferOffset = 0
-      }
-      // Concat the new buffer with the remaining one
-      buffer.copy(this.buffer, this.bufferOffset + this.bufferLength)
-      this.bufferLength = newLength
-    } else {
-      this.buffer = buffer
-      this.bufferOffset = 0
-      this.bufferLength = buffer.byteLength
-    }
-  }
-
-  private handlePacket(offset: number, code: number, length: number, bytes: Buffer): BackendMessage {
-    switch (code) {
-      case MessageCodes.BindComplete:
-        return bindComplete
-      case MessageCodes.ParseComplete:
-        return parseComplete
-      case MessageCodes.CloseComplete:
-        return closeComplete
-      case MessageCodes.NoData:
-        return noData
-      case MessageCodes.PortalSuspended:
-        return portalSuspended
-      case MessageCodes.CopyDone:
-        return copyDone
-      case MessageCodes.ReplicationStart:
-        return replicationStart
-      case MessageCodes.EmptyQuery:
-        return emptyQuery
-      case MessageCodes.DataRow:
-        return this.parseDataRowMessage(offset, length, bytes)
-      case MessageCodes.CommandComplete:
-        return this.parseCommandCompleteMessage(offset, length, bytes)
-      case MessageCodes.ReadyForQuery:
-        return this.parseReadyForQueryMessage(offset, length, bytes)
-      case MessageCodes.NotificationResponse:
-        return this.parseNotificationMessage(offset, length, bytes)
-      case MessageCodes.AuthenticationResponse:
-        return this.parseAuthenticationResponse(offset, length, bytes)
-      case MessageCodes.ParameterStatus:
-        return this.parseParameterStatusMessage(offset, length, bytes)
-      case MessageCodes.BackendKeyData:
-        return this.parseBackendKeyData(offset, length, bytes)
-      case MessageCodes.ErrorMessage:
-        return this.parseErrorMessage(offset, length, bytes, 'error')
-      case MessageCodes.NoticeMessage:
-        return this.parseErrorMessage(offset, length, bytes, 'notice')
-      case MessageCodes.RowDescriptionMessage:
-        return this.parseRowDescriptionMessage(offset, length, bytes)
-      case MessageCodes.ParameterDescriptionMessage:
-        return this.parseParameterDescriptionMessage(offset, length, bytes)
-      case MessageCodes.CommandDescriptionMessage:
-        return this.parseCommandDescriptionMessage(offset, length, bytes)
-      case MessageCodes.CopyIn:
-        return this.parseCopyInMessage(offset, length, bytes)
-      case MessageCodes.CopyOut:
-        return this.parseCopyOutMessage(offset, length, bytes)
-      case MessageCodes.CopyData:
-        return this.parseCopyData(offset, length, bytes)
-      default:
-        assert.fail(`unknown message code: ${code.toString(16)}`)
-    }
-  }
-
-  private parseReadyForQueryMessage(offset: number, length: number, bytes: Buffer) {
-    this.reader.setBuffer(offset, bytes)
-    const status = this.reader.string(1)
-    return new ReadyForQueryMessage(length, status)
-  }
-
-  private parseCommandCompleteMessage(offset: number, length: number, bytes: Buffer) {
-    this.reader.setBuffer(offset, bytes)
-    const text = this.reader.cstring()
-    return new CommandCompleteMessage(length, text)
-  }
-
-  private parseCopyData(offset: number, length: number, bytes: Buffer) {
-    const chunk = bytes.slice(offset, offset + (length - 4))
-    return new CopyDataMessage(length, chunk)
-  }
-
-  private parseCopyInMessage(offset: number, length: number, bytes: Buffer) {
-    return this.parseCopyMessage(offset, length, bytes, 'copyInResponse')
-  }
-
-  private parseCopyOutMessage(offset: number, length: number, bytes: Buffer) {
-    return this.parseCopyMessage(offset, length, bytes, 'copyOutResponse')
-  }
-
-  private parseCopyMessage(offset: number, length: number, bytes: Buffer, messageName: MessageName) {
-    this.reader.setBuffer(offset, bytes)
-    const isBinary = this.reader.byte() !== 0
-    const columnCount = this.reader.int16()
-    const message = new CopyResponse(length, messageName, isBinary, columnCount)
-    for (let i = 0; i < columnCount; i++) {
-      message.columnTypes[i] = this.reader.int16()
-    }
-    return message
-  }
-
-  private parseNotificationMessage(offset: number, length: number, bytes: Buffer) {
-    this.reader.setBuffer(offset, bytes)
-    const processId = this.reader.int32()
-    const channel = this.reader.cstring()
-    const payload = this.reader.cstring()
-    return new NotificationResponseMessage(length, processId, channel, payload)
-  }
-
-  private parseRowDescriptionMessage(offset: number, length: number, bytes: Buffer) {
-    this.reader.setBuffer(offset, bytes)
-    const fieldCount = this.reader.int16()
-    const message = new RowDescriptionMessage(length, fieldCount)
-    if (fieldCount === 0) {
-      return message
-    }
-    const nonNativeTypeCount = this.reader.int32()
-    if (nonNativeTypeCount > 0) {
-      throw new Error("Non native types are not yet supported")
-    }
-    for (let i = 0; i < fieldCount; i++) {
-      message.fields[i] = this.parseField()
-    }
-    return message
-  }
-
-  private parseField(): Field {
-    const name = this.reader.cstring()
-    const tableID = this.reader.uint64()
-    const schemaName = this.reader.cstring()
-    const tableName = this.reader.cstring()
-    const columnID = this.reader.int16()
-    const parentTypeID = this.reader.int16()
-    const isNonNative = this.reader.bytes(1)
-    if (isNonNative[0] == 1) {
-      throw new Error("Non native types are not yet supported")
-    }
-    const dataTypeID = this.reader.int32() // for non native types this would be the index into the type mapping pool
-    const dataTypeSize = this.reader.int16()
-    const allowsNull = this.reader.int16()
-    const isIdentity = this.reader.int16()
-    const dataTypeModifier = this.reader.int32()
-    const mode = this.reader.int16() === 0 ? 'text' : 'binary'
-    return new Field(name, tableID, columnID, dataTypeID, dataTypeSize, dataTypeModifier, mode)
-  }
-
-  private parseParameterDescriptionMessage(offset: number, length: number, bytes: Buffer) {
-    this.reader.setBuffer(offset, bytes)
-    const parameterCount = this.reader.int16()
-    const message = new ParameterDescriptionMessage(length, parameterCount)
-    if (parameterCount === 0) {
-      return message
-    }
-    const nonNativeTypeCount = this.reader.int32() 
-    if (nonNativeTypeCount > 0 ) {
-      throw new Error("Non native types are not yet supported")
-    }
-    for (let i = 0; i < parameterCount; i++) {
-      message.parameters[i] = this.parseParameter()
-    }
-    return message
-  }
-
-  private parseParameter(): Parameter {
-    const isNonNative = this.reader.byte() !== 0
-    if (isNonNative) { // should have been caught already, but just in case
-      throw new Error("Non native types are not yet supported")
-    }
-    const oid = this.reader.int32()
-    const typemod = this.reader.int32()
-    const hasNotNull = this.reader.int16()
-    return new Parameter(isNonNative, oid, typemod, hasNotNull);
-  }
-
-  private parseCommandDescriptionMessage(offset: number, length: number, bytes: Buffer) {
-    this.reader.setBuffer(offset, bytes)
-    const tag = this.reader.cstring()
-    const convertedToCopy = this.reader.int16()
-    const convertedStatement = this.reader.cstring()
-
-    return new CommandDescriptionMessage(length, tag, convertedToCopy, convertedStatement)
-  }
-
-  private parseDataRowMessage(offset: number, length: number, bytes: Buffer) {
-    this.reader.setBuffer(offset, bytes)
-    const fieldCount = this.reader.int16()
-    const fields: any[] = new Array(fieldCount)
-    for (let i = 0; i < fieldCount; i++) {
-      const len = this.reader.int32()
-      // a -1 for length means the value of the field is null
-      fields[i] = len === -1 ? null : this.reader.string(len)
-    }
-    return new DataRowMessage(length, fields)
-  }
-
-  private parseParameterStatusMessage(offset: number, length: number, bytes: Buffer) {
-    this.reader.setBuffer(offset, bytes)
-    const name = this.reader.cstring()
-    const value = this.reader.cstring()
-    return new ParameterStatusMessage(length, name, value)
-  }
-
-  private parseBackendKeyData(offset: number, length: number, bytes: Buffer) {
-    this.reader.setBuffer(offset, bytes)
-    const processID = this.reader.int32()
-    const secretKey = this.reader.int32()
-    return new BackendKeyDataMessage(length, processID, secretKey)
-  }
-
-  public parseAuthenticationResponse(offset: number, length: number, bytes: Buffer) {
-    this.reader.setBuffer(offset, bytes)
-    const code = this.reader.int32()
-    // TODO(bmc): maybe better types here
-    const message: BackendMessage & any = {
-      name: 'authenticationOk',
-      length,
-    }
-
-    switch (code) {
-      case 0: // AuthenticationOk
-        break
-      case 3: // AuthenticationCleartextPassword
-        if (message.length === 8) {
-          message.name = 'authenticationCleartextPassword'
-        }
-        break
-      case 5: // AuthenticationMD5Password
-        if (message.length === 12) {
-          message.name = 'authenticationMD5Password'
-          const salt = this.reader.bytes(4)
-          return new AuthenticationMD5Password(length, salt)
-        }
-        break
-      case 65536: // AuthenticationHashPassword
-      case 66048: // AuthenticationHashSHA512Password
-        if(message.length === 32) {
-          const salt = this.reader.bytes(4)
-          const userSaltLen = this.reader.int32()
-          const userSalt = this.reader.bytes(16)
-
-          return new AuthenticationSHA512Password(length, salt, userSalt)
-        }
-        break
-      case 9: // PasswordExpired
-        return new DatabaseError('Could not authenticate: Password expired.', 0, 'error')
-      default:
-        throw new Error('Unknown authentication request message type ' + code)
-    }
-    return message
-  }
-
-  private parseErrorMessage(offset: number, length: number, bytes: Buffer, name: MessageName) {
-    this.reader.setBuffer(offset, bytes)
-    const fields: Record<string, string> = {}
-    let fieldType = this.reader.string(1)
-    while (fieldType !== '\0') {
-      fields[fieldType] = this.reader.cstring()
-      fieldType = this.reader.string(1)
-    }
-
-    const messageValue = fields.M
-
-    const message =
-      name === 'notice' ? new NoticeMessage(length, messageValue) : new DatabaseError(messageValue, length, name)
-
-    message.severity = fields.S
-    message.code = fields.C
-    message.detail = fields.D
-    message.hint = fields.H
-    message.position = fields.P
-    message.internalPosition = fields.p
-    message.internalQuery = fields.q
-    message.where = fields.W
-    message.schema = fields.s
-    message.table = fields.t
-    message.column = fields.c
-    message.dataType = fields.d
-    message.constraint = fields.n
-    message.file = fields.F
-    message.line = fields.L
-    message.routine = fields.R
-    return message
-  }
-}
+ import { TransformOptions } from 'stream'
+ import {
+   Mode,
+   bindComplete,
+   parseComplete,
+   closeComplete,
+   noData,
+   portalSuspended,
+   copyDone,
+   replicationStart,
+   emptyQuery,
+   ReadyForQueryMessage,
+   CommandCompleteMessage,
+   CopyDataMessage,
+   CopyResponse,
+   NotificationResponseMessage,
+   RowDescriptionMessage,
+   ParameterDescriptionMessage,
+   Parameter,
+   CommandDescriptionMessage,
+   Field,
+   DataRowMessage,
+   ParameterStatusMessage,
+   BackendKeyDataMessage,
+   DatabaseError,
+   BackendMessage,
+   MessageName,
+   AuthenticationMD5Password,
+   NoticeMessage,
+   AuthenticationSHA512Password,
+ } from './messages'
+ import { BufferReader } from './buffer-reader'
+ import assert from 'assert'
+ 
+ // every message is prefixed with a single bye
+ const CODE_LENGTH = 1
+ // every message has an int32 length which includes itself but does
+ // NOT include the code in the length
+ const LEN_LENGTH = 4
+ 
+ const HEADER_LENGTH = CODE_LENGTH + LEN_LENGTH
+ 
+ export type Packet = {
+   code: number
+   packet: Buffer
+ }
+ 
+ const emptyBuffer = Buffer.allocUnsafe(0)
+ 
+ type StreamOptions = TransformOptions & {
+   mode: Mode
+ }
+ 
+ const enum MessageCodes {
+   DataRow = 0x44, // D
+   ParseComplete = 0x31, // 1
+   BindComplete = 0x32, // 2
+   CloseComplete = 0x33, // 3
+   CommandComplete = 0x43, // C
+   ReadyForQuery = 0x5a, // Z
+   NoData = 0x6e, // n
+   NotificationResponse = 0x41, // A
+   AuthenticationResponse = 0x52, // R
+   ParameterStatus = 0x53, // S
+   BackendKeyData = 0x4b, // K
+   ErrorMessage = 0x45, // E
+   NoticeMessage = 0x4e, // N
+   RowDescriptionMessage = 0x54, // T
+   ParameterDescriptionMessage = 0x74, // t
+   CommandDescriptionMessage = 0x6d, // m
+   PortalSuspended = 0x73, // s
+   ReplicationStart = 0x57, // W
+   EmptyQuery = 0x49, // I
+   CopyIn = 0x47, // G
+   CopyOut = 0x48, // H
+   CopyDone = 0x63, // c
+   CopyData = 0x64, // d
+ }
+ 
+ export type MessageCallback = (msg: BackendMessage) => void
+ 
+ export class Parser {
+   private buffer: Buffer = emptyBuffer
+   private bufferLength: number = 0
+   private bufferOffset: number = 0
+   private reader = new BufferReader()
+   private mode: Mode
+ 
+   constructor(opts?: StreamOptions) {
+     if (opts?.mode === 'binary') {
+       throw new Error('Binary mode not supported yet')
+     }
+     this.mode = opts?.mode || 'text'
+   }
+ 
+   public parse(buffer: Buffer, callback: MessageCallback) {
+     this.mergeBuffer(buffer)
+     const bufferFullLength = this.bufferOffset + this.bufferLength
+     let offset = this.bufferOffset
+     while (offset + HEADER_LENGTH <= bufferFullLength) {
+       // code is 1 byte long - it identifies the message type
+       const code = this.buffer[offset]
+       // length is 1 Uint32BE - it is the length of the message EXCLUDING the code
+       const length = this.buffer.readUInt32BE(offset + CODE_LENGTH)
+       const fullMessageLength = CODE_LENGTH + length
+       if (fullMessageLength + offset <= bufferFullLength) {
+         const message = this.handlePacket(offset + HEADER_LENGTH, code, length, this.buffer)
+         callback(message)
+         offset += fullMessageLength
+       } else {
+         break
+       }
+     }
+     if (offset === bufferFullLength) {
+       // No more use for the buffer
+       this.buffer = emptyBuffer
+       this.bufferLength = 0
+       this.bufferOffset = 0
+     } else {
+       // Adjust the cursors of remainingBuffer
+       this.bufferLength = bufferFullLength - offset
+       this.bufferOffset = offset
+     }
+   }
+ 
+   private mergeBuffer(buffer: Buffer): void {
+     if (this.bufferLength > 0) {
+       const newLength = this.bufferLength + buffer.byteLength
+       const newFullLength = newLength + this.bufferOffset
+       if (newFullLength > this.buffer.byteLength) {
+         // We can't concat the new buffer with the remaining one
+         let newBuffer: Buffer
+         if (newLength <= this.buffer.byteLength && this.bufferOffset >= this.bufferLength) {
+           // We can move the relevant part to the beginning of the buffer instead of allocating a new buffer
+           newBuffer = this.buffer
+         } else {
+           // Allocate a new larger buffer
+           let newBufferLength = this.buffer.byteLength * 2
+           while (newLength >= newBufferLength) {
+             newBufferLength *= 2
+           }
+           newBuffer = Buffer.allocUnsafe(newBufferLength)
+         }
+         // Move the remaining buffer to the new one
+         this.buffer.copy(newBuffer, 0, this.bufferOffset, this.bufferOffset + this.bufferLength)
+         this.buffer = newBuffer
+         this.bufferOffset = 0
+       }
+       // Concat the new buffer with the remaining one
+       buffer.copy(this.buffer, this.bufferOffset + this.bufferLength)
+       this.bufferLength = newLength
+     } else {
+       this.buffer = buffer
+       this.bufferOffset = 0
+       this.bufferLength = buffer.byteLength
+     }
+   }
+ 
+   private handlePacket(offset: number, code: number, length: number, bytes: Buffer): BackendMessage {
+     switch (code) {
+       case MessageCodes.BindComplete:
+         return bindComplete
+       case MessageCodes.ParseComplete:
+         return parseComplete
+       case MessageCodes.CloseComplete:
+         return closeComplete
+       case MessageCodes.NoData:
+         return noData
+       case MessageCodes.PortalSuspended:
+         return portalSuspended
+       case MessageCodes.CopyDone:
+         return copyDone
+       case MessageCodes.ReplicationStart:
+         return replicationStart
+       case MessageCodes.EmptyQuery:
+         return emptyQuery
+       case MessageCodes.DataRow:
+         return this.parseDataRowMessage(offset, length, bytes)
+       case MessageCodes.CommandComplete:
+         return this.parseCommandCompleteMessage(offset, length, bytes)
+       case MessageCodes.ReadyForQuery:
+         return this.parseReadyForQueryMessage(offset, length, bytes)
+       case MessageCodes.NotificationResponse:
+         return this.parseNotificationMessage(offset, length, bytes)
+       case MessageCodes.AuthenticationResponse:
+         return this.parseAuthenticationResponse(offset, length, bytes)
+       case MessageCodes.ParameterStatus:
+         return this.parseParameterStatusMessage(offset, length, bytes)
+       case MessageCodes.BackendKeyData:
+         return this.parseBackendKeyData(offset, length, bytes)
+       case MessageCodes.ErrorMessage:
+         return this.parseErrorMessage(offset, length, bytes, 'error')
+       case MessageCodes.NoticeMessage:
+         return this.parseErrorMessage(offset, length, bytes, 'notice')
+       case MessageCodes.RowDescriptionMessage:
+         return this.parseRowDescriptionMessage(offset, length, bytes)
+       case MessageCodes.ParameterDescriptionMessage:
+         return this.parseParameterDescriptionMessage(offset, length, bytes)
+       case MessageCodes.CommandDescriptionMessage:
+         return this.parseCommandDescriptionMessage(offset, length, bytes)
+       case MessageCodes.CopyIn:
+         return this.parseCopyInMessage(offset, length, bytes)
+       case MessageCodes.CopyOut:
+         return this.parseCopyOutMessage(offset, length, bytes)
+       case MessageCodes.CopyData:
+         return this.parseCopyData(offset, length, bytes)
+       default:
+         assert.fail(`unknown message code: ${code.toString(16)}`)
+     }
+   }
+ 
+   private parseReadyForQueryMessage(offset: number, length: number, bytes: Buffer) {
+     this.reader.setBuffer(offset, bytes)
+     const status = this.reader.string(1)
+     return new ReadyForQueryMessage(length, status)
+   }
+ 
+   private parseCommandCompleteMessage(offset: number, length: number, bytes: Buffer) {
+     this.reader.setBuffer(offset, bytes)
+     const text = this.reader.cstring()
+     return new CommandCompleteMessage(length, text)
+   }
+ 
+   private parseCopyData(offset: number, length: number, bytes: Buffer) {
+     const chunk = bytes.slice(offset, offset + (length - 4))
+     return new CopyDataMessage(length, chunk)
+   }
+ 
+   private parseCopyInMessage(offset: number, length: number, bytes: Buffer) {
+     return this.parseCopyMessage(offset, length, bytes, 'copyInResponse')
+   }
+ 
+   private parseCopyOutMessage(offset: number, length: number, bytes: Buffer) {
+     return this.parseCopyMessage(offset, length, bytes, 'copyOutResponse')
+   }
+ 
+   private parseCopyMessage(offset: number, length: number, bytes: Buffer, messageName: MessageName) {
+     this.reader.setBuffer(offset, bytes)
+     const isBinary = this.reader.byte() !== 0
+     const columnCount = this.reader.int16()
+     const message = new CopyResponse(length, messageName, isBinary, columnCount)
+     for (let i = 0; i < columnCount; i++) {
+       message.columnTypes[i] = this.reader.int16()
+     }
+     return message
+   }
+ 
+   private parseNotificationMessage(offset: number, length: number, bytes: Buffer) {
+     this.reader.setBuffer(offset, bytes)
+     const processId = this.reader.int32()
+     const channel = this.reader.cstring()
+     const payload = this.reader.cstring()
+     return new NotificationResponseMessage(length, processId, channel, payload)
+   }
+ 
+   private parseRowDescriptionMessage(offset: number, length: number, bytes: Buffer) {
+     this.reader.setBuffer(offset, bytes)
+     const fieldCount = this.reader.int16()
+     const message = new RowDescriptionMessage(length, fieldCount)
+     if (fieldCount === 0) {
+       return message
+     }
+     const nonNativeTypeCount = this.reader.int32()
+     if (nonNativeTypeCount > 0) {
+       throw new Error("Non native types are not yet supported")
+     }
+     for (let i = 0; i < fieldCount; i++) {
+       message.fields[i] = this.parseField()
+     }
+     return message
+   }
+ 
+   private parseField(): Field {
+     const name = this.reader.cstring()
+     const tableID = this.reader.uint64()
+     const schemaName = this.reader.cstring()
+     const tableName = this.reader.cstring()
+     const columnID = this.reader.int16()
+     //const parentTypeID = this.reader.int16() // breadcrumb for complex types
+     const isNonNative = this.reader.bytes(1)
+     if (isNonNative[0] == 1) {
+       throw new Error("Non native types are not yet supported")
+     }
+     const dataTypeID = this.reader.int32() // for non native types this would be the index into the type mapping pool
+     const dataTypeSize = this.reader.int16()
+     const allowsNull = this.reader.int16()
+     const isIdentity = this.reader.int16()
+     const dataTypeModifier = this.reader.int32()
+     const mode = this.reader.int16() === 0 ? 'text' : 'binary'
+     return new Field(name, tableID, schemaName, tableName, columnID, dataTypeID, dataTypeSize, allowsNull, isIdentity, dataTypeModifier, mode)
+   }
+ 
+   private parseParameterDescriptionMessage(offset: number, length: number, bytes: Buffer) {
+     this.reader.setBuffer(offset, bytes)
+     const parameterCount = this.reader.int16()
+     const message = new ParameterDescriptionMessage(length, parameterCount)
+     if (parameterCount === 0) {
+       return message
+     }
+     const nonNativeTypeCount = this.reader.int32() 
+     if (nonNativeTypeCount > 0 ) {
+       throw new Error("Non native types are not yet supported")
+     }
+     for (let i = 0; i < parameterCount; i++) {
+       message.parameters[i] = this.parseParameter()
+     }
+     return message
+   }
+ 
+   private parseParameter(): Parameter {
+     const isNonNative = this.reader.byte() !== 0
+     if (isNonNative) { // should have been caught already, but just in case
+       throw new Error("Non native types are not yet supported")
+     }
+     const oid = this.reader.int32()
+     const typemod = this.reader.int32()
+     const hasNotNull = this.reader.int16()
+     return new Parameter(isNonNative, oid, typemod, hasNotNull);
+   }
+ 
+   private parseCommandDescriptionMessage(offset: number, length: number, bytes: Buffer) {
+     this.reader.setBuffer(offset, bytes)
+     const tag = this.reader.cstring()
+     const convertedToCopy = this.reader.int16()
+     const convertedStatement = this.reader.cstring()
+ 
+     return new CommandDescriptionMessage(length, tag, convertedToCopy, convertedStatement)
+   }
+ 
+   private parseDataRowMessage(offset: number, length: number, bytes: Buffer) {
+     this.reader.setBuffer(offset, bytes)
+     const fieldCount = this.reader.int16()
+     const fields: any[] = new Array(fieldCount)
+     for (let i = 0; i < fieldCount; i++) {
+       const len = this.reader.int32()
+       // a -1 for length means the value of the field is null
+       fields[i] = len === -1 ? null : this.reader.string(len)
+     }
+     return new DataRowMessage(length, fields)
+   }
+ 
+   private parseParameterStatusMessage(offset: number, length: number, bytes: Buffer) {
+     this.reader.setBuffer(offset, bytes)
+     const name = this.reader.cstring()
+     const value = this.reader.cstring()
+     return new ParameterStatusMessage(length, name, value)
+   }
+ 
+   private parseBackendKeyData(offset: number, length: number, bytes: Buffer) {
+     this.reader.setBuffer(offset, bytes)
+     const processID = this.reader.int32()
+     const secretKey = this.reader.int32()
+     return new BackendKeyDataMessage(length, processID, secretKey)
+   }
+ 
+   public parseAuthenticationResponse(offset: number, length: number, bytes: Buffer) {
+     this.reader.setBuffer(offset, bytes)
+     const code = this.reader.int32()
+     // TODO(bmc): maybe better types here
+     const message: BackendMessage & any = {
+       name: 'authenticationOk',
+       length,
+     }
+ 
+     switch (code) {
+       case 0: // AuthenticationOk
+         break
+       case 3: // AuthenticationCleartextPassword
+         if (message.length === 8) {
+           message.name = 'authenticationCleartextPassword'
+         }
+         break
+       case 5: // AuthenticationMD5Password
+         if (message.length === 12) {
+           message.name = 'authenticationMD5Password'
+           const salt = this.reader.bytes(4)
+           return new AuthenticationMD5Password(length, salt)
+         }
+         break
+       case 65536: // AuthenticationHashPassword
+       case 66048: // AuthenticationHashSHA512Password
+         if(message.length === 32) {
+           const salt = this.reader.bytes(4)
+           const userSaltLen = this.reader.int32()
+           const userSalt = this.reader.bytes(16)
+ 
+           return new AuthenticationSHA512Password(length, salt, userSalt)
+         }
+         break
+       case 9: // PasswordExpired
+         return new DatabaseError('Could not authenticate: Password expired.', 0, 'error')
+       default:
+         throw new Error('Unknown authentication request message type ' + code)
+     }
+     return message
+   }
+ 
+   private parseErrorMessage(offset: number, length: number, bytes: Buffer, name: MessageName) {
+     this.reader.setBuffer(offset, bytes)
+     const fields: Record<string, string> = {}
+     let fieldType = this.reader.string(1)
+     while (fieldType !== '\0') {
+       fields[fieldType] = this.reader.cstring()
+       fieldType = this.reader.string(1)
+     }
+ 
+     const messageValue = fields.M
+ 
+     const message =
+       name === 'notice' ? new NoticeMessage(length, messageValue) : new DatabaseError(messageValue, length, name)
+ 
+     message.severity = fields.S
+     message.code = fields.C
+     message.detail = fields.D
+     message.hint = fields.H
+     message.position = fields.P
+     message.internalPosition = fields.p
+     message.internalQuery = fields.q
+     message.where = fields.W
+     message.schema = fields.s
+     message.table = fields.t
+     message.column = fields.c
+     message.dataType = fields.d
+     message.constraint = fields.n
+     message.file = fields.F
+     message.line = fields.L
+     message.routine = fields.R
+     return message
+   }
+ }
+ 

--- a/packages/v-protocol/src/parser.ts
+++ b/packages/v-protocol/src/parser.ts
@@ -16,434 +16,433 @@
  * =============================================================================
  */
 
- import { TransformOptions } from 'stream'
- import {
-   Mode,
-   bindComplete,
-   parseComplete,
-   closeComplete,
-   noData,
-   portalSuspended,
-   copyDone,
-   replicationStart,
-   emptyQuery,
-   ReadyForQueryMessage,
-   CommandCompleteMessage,
-   CopyDataMessage,
-   CopyResponse,
-   NotificationResponseMessage,
-   RowDescriptionMessage,
-   ParameterDescriptionMessage,
-   Parameter,
-   CommandDescriptionMessage,
-   Field,
-   DataRowMessage,
-   ParameterStatusMessage,
-   BackendKeyDataMessage,
-   DatabaseError,
-   BackendMessage,
-   MessageName,
-   AuthenticationMD5Password,
-   NoticeMessage,
-   AuthenticationSHA512Password,
- } from './messages'
- import { BufferReader } from './buffer-reader'
- import assert from 'assert'
- 
- // every message is prefixed with a single bye
- const CODE_LENGTH = 1
- // every message has an int32 length which includes itself but does
- // NOT include the code in the length
- const LEN_LENGTH = 4
- 
- const HEADER_LENGTH = CODE_LENGTH + LEN_LENGTH
- 
- export type Packet = {
-   code: number
-   packet: Buffer
- }
- 
- const emptyBuffer = Buffer.allocUnsafe(0)
- 
- type StreamOptions = TransformOptions & {
-   mode: Mode
- }
- 
- const enum MessageCodes {
-   DataRow = 0x44, // D
-   ParseComplete = 0x31, // 1
-   BindComplete = 0x32, // 2
-   CloseComplete = 0x33, // 3
-   CommandComplete = 0x43, // C
-   ReadyForQuery = 0x5a, // Z
-   NoData = 0x6e, // n
-   NotificationResponse = 0x41, // A
-   AuthenticationResponse = 0x52, // R
-   ParameterStatus = 0x53, // S
-   BackendKeyData = 0x4b, // K
-   ErrorMessage = 0x45, // E
-   NoticeMessage = 0x4e, // N
-   RowDescriptionMessage = 0x54, // T
-   ParameterDescriptionMessage = 0x74, // t
-   CommandDescriptionMessage = 0x6d, // m
-   PortalSuspended = 0x73, // s
-   ReplicationStart = 0x57, // W
-   EmptyQuery = 0x49, // I
-   CopyIn = 0x47, // G
-   CopyOut = 0x48, // H
-   CopyDone = 0x63, // c
-   CopyData = 0x64, // d
- }
- 
- export type MessageCallback = (msg: BackendMessage) => void
- 
- export class Parser {
-   private buffer: Buffer = emptyBuffer
-   private bufferLength: number = 0
-   private bufferOffset: number = 0
-   private reader = new BufferReader()
-   private mode: Mode
- 
-   constructor(opts?: StreamOptions) {
-     if (opts?.mode === 'binary') {
-       throw new Error('Binary mode not supported yet')
-     }
-     this.mode = opts?.mode || 'text'
-   }
- 
-   public parse(buffer: Buffer, callback: MessageCallback) {
-     this.mergeBuffer(buffer)
-     const bufferFullLength = this.bufferOffset + this.bufferLength
-     let offset = this.bufferOffset
-     while (offset + HEADER_LENGTH <= bufferFullLength) {
-       // code is 1 byte long - it identifies the message type
-       const code = this.buffer[offset]
-       // length is 1 Uint32BE - it is the length of the message EXCLUDING the code
-       const length = this.buffer.readUInt32BE(offset + CODE_LENGTH)
-       const fullMessageLength = CODE_LENGTH + length
-       if (fullMessageLength + offset <= bufferFullLength) {
-         const message = this.handlePacket(offset + HEADER_LENGTH, code, length, this.buffer)
-         callback(message)
-         offset += fullMessageLength
-       } else {
-         break
-       }
-     }
-     if (offset === bufferFullLength) {
-       // No more use for the buffer
-       this.buffer = emptyBuffer
-       this.bufferLength = 0
-       this.bufferOffset = 0
-     } else {
-       // Adjust the cursors of remainingBuffer
-       this.bufferLength = bufferFullLength - offset
-       this.bufferOffset = offset
-     }
-   }
- 
-   private mergeBuffer(buffer: Buffer): void {
-     if (this.bufferLength > 0) {
-       const newLength = this.bufferLength + buffer.byteLength
-       const newFullLength = newLength + this.bufferOffset
-       if (newFullLength > this.buffer.byteLength) {
-         // We can't concat the new buffer with the remaining one
-         let newBuffer: Buffer
-         if (newLength <= this.buffer.byteLength && this.bufferOffset >= this.bufferLength) {
-           // We can move the relevant part to the beginning of the buffer instead of allocating a new buffer
-           newBuffer = this.buffer
-         } else {
-           // Allocate a new larger buffer
-           let newBufferLength = this.buffer.byteLength * 2
-           while (newLength >= newBufferLength) {
-             newBufferLength *= 2
-           }
-           newBuffer = Buffer.allocUnsafe(newBufferLength)
-         }
-         // Move the remaining buffer to the new one
-         this.buffer.copy(newBuffer, 0, this.bufferOffset, this.bufferOffset + this.bufferLength)
-         this.buffer = newBuffer
-         this.bufferOffset = 0
-       }
-       // Concat the new buffer with the remaining one
-       buffer.copy(this.buffer, this.bufferOffset + this.bufferLength)
-       this.bufferLength = newLength
-     } else {
-       this.buffer = buffer
-       this.bufferOffset = 0
-       this.bufferLength = buffer.byteLength
-     }
-   }
- 
-   private handlePacket(offset: number, code: number, length: number, bytes: Buffer): BackendMessage {
-     switch (code) {
-       case MessageCodes.BindComplete:
-         return bindComplete
-       case MessageCodes.ParseComplete:
-         return parseComplete
-       case MessageCodes.CloseComplete:
-         return closeComplete
-       case MessageCodes.NoData:
-         return noData
-       case MessageCodes.PortalSuspended:
-         return portalSuspended
-       case MessageCodes.CopyDone:
-         return copyDone
-       case MessageCodes.ReplicationStart:
-         return replicationStart
-       case MessageCodes.EmptyQuery:
-         return emptyQuery
-       case MessageCodes.DataRow:
-         return this.parseDataRowMessage(offset, length, bytes)
-       case MessageCodes.CommandComplete:
-         return this.parseCommandCompleteMessage(offset, length, bytes)
-       case MessageCodes.ReadyForQuery:
-         return this.parseReadyForQueryMessage(offset, length, bytes)
-       case MessageCodes.NotificationResponse:
-         return this.parseNotificationMessage(offset, length, bytes)
-       case MessageCodes.AuthenticationResponse:
-         return this.parseAuthenticationResponse(offset, length, bytes)
-       case MessageCodes.ParameterStatus:
-         return this.parseParameterStatusMessage(offset, length, bytes)
-       case MessageCodes.BackendKeyData:
-         return this.parseBackendKeyData(offset, length, bytes)
-       case MessageCodes.ErrorMessage:
-         return this.parseErrorMessage(offset, length, bytes, 'error')
-       case MessageCodes.NoticeMessage:
-         return this.parseErrorMessage(offset, length, bytes, 'notice')
-       case MessageCodes.RowDescriptionMessage:
-         return this.parseRowDescriptionMessage(offset, length, bytes)
-       case MessageCodes.ParameterDescriptionMessage:
-         return this.parseParameterDescriptionMessage(offset, length, bytes)
-       case MessageCodes.CommandDescriptionMessage:
-         return this.parseCommandDescriptionMessage(offset, length, bytes)
-       case MessageCodes.CopyIn:
-         return this.parseCopyInMessage(offset, length, bytes)
-       case MessageCodes.CopyOut:
-         return this.parseCopyOutMessage(offset, length, bytes)
-       case MessageCodes.CopyData:
-         return this.parseCopyData(offset, length, bytes)
-       default:
-         assert.fail(`unknown message code: ${code.toString(16)}`)
-     }
-   }
- 
-   private parseReadyForQueryMessage(offset: number, length: number, bytes: Buffer) {
-     this.reader.setBuffer(offset, bytes)
-     const status = this.reader.string(1)
-     return new ReadyForQueryMessage(length, status)
-   }
- 
-   private parseCommandCompleteMessage(offset: number, length: number, bytes: Buffer) {
-     this.reader.setBuffer(offset, bytes)
-     const text = this.reader.cstring()
-     return new CommandCompleteMessage(length, text)
-   }
- 
-   private parseCopyData(offset: number, length: number, bytes: Buffer) {
-     const chunk = bytes.slice(offset, offset + (length - 4))
-     return new CopyDataMessage(length, chunk)
-   }
- 
-   private parseCopyInMessage(offset: number, length: number, bytes: Buffer) {
-     return this.parseCopyMessage(offset, length, bytes, 'copyInResponse')
-   }
- 
-   private parseCopyOutMessage(offset: number, length: number, bytes: Buffer) {
-     return this.parseCopyMessage(offset, length, bytes, 'copyOutResponse')
-   }
- 
-   private parseCopyMessage(offset: number, length: number, bytes: Buffer, messageName: MessageName) {
-     this.reader.setBuffer(offset, bytes)
-     const isBinary = this.reader.byte() !== 0
-     const columnCount = this.reader.int16()
-     const message = new CopyResponse(length, messageName, isBinary, columnCount)
-     for (let i = 0; i < columnCount; i++) {
-       message.columnTypes[i] = this.reader.int16()
-     }
-     return message
-   }
- 
-   private parseNotificationMessage(offset: number, length: number, bytes: Buffer) {
-     this.reader.setBuffer(offset, bytes)
-     const processId = this.reader.int32()
-     const channel = this.reader.cstring()
-     const payload = this.reader.cstring()
-     return new NotificationResponseMessage(length, processId, channel, payload)
-   }
- 
-   private parseRowDescriptionMessage(offset: number, length: number, bytes: Buffer) {
-     this.reader.setBuffer(offset, bytes)
-     const fieldCount = this.reader.int16()
-     const message = new RowDescriptionMessage(length, fieldCount)
-     if (fieldCount === 0) {
-       return message
-     }
-     const nonNativeTypeCount = this.reader.int32()
-     if (nonNativeTypeCount > 0) {
-       throw new Error("Non native types are not yet supported")
-     }
-     for (let i = 0; i < fieldCount; i++) {
-       message.fields[i] = this.parseField()
-     }
-     return message
-   }
- 
-   private parseField(): Field {
-     const name = this.reader.cstring()
-     const tableID = this.reader.uint64()
-     const schemaName = this.reader.cstring()
-     const tableName = this.reader.cstring()
-     const columnID = this.reader.int16()
-     //const parentTypeID = this.reader.int16() // breadcrumb for complex types
-     const isNonNative = this.reader.bytes(1)
-     if (isNonNative[0] == 1) {
-       throw new Error("Non native types are not yet supported")
-     }
-     const dataTypeID = this.reader.int32() // for non native types this would be the index into the type mapping pool
-     const dataTypeSize = this.reader.int16()
-     const allowsNull = this.reader.int16()
-     const isIdentity = this.reader.int16()
-     const dataTypeModifier = this.reader.int32()
-     const mode = this.reader.int16() === 0 ? 'text' : 'binary'
-     return new Field(name, tableID, schemaName, tableName, columnID, dataTypeID, dataTypeSize, allowsNull, isIdentity, dataTypeModifier, mode)
-   }
- 
-   private parseParameterDescriptionMessage(offset: number, length: number, bytes: Buffer) {
-     this.reader.setBuffer(offset, bytes)
-     const parameterCount = this.reader.int16()
-     const message = new ParameterDescriptionMessage(length, parameterCount)
-     if (parameterCount === 0) {
-       return message
-     }
-     const nonNativeTypeCount = this.reader.int32() 
-     if (nonNativeTypeCount > 0 ) {
-       throw new Error("Non native types are not yet supported")
-     }
-     for (let i = 0; i < parameterCount; i++) {
-       message.parameters[i] = this.parseParameter()
-     }
-     return message
-   }
- 
-   private parseParameter(): Parameter {
-     const isNonNative = this.reader.byte() !== 0
-     if (isNonNative) { // should have been caught already, but just in case
-       throw new Error("Non native types are not yet supported")
-     }
-     const oid = this.reader.int32()
-     const typemod = this.reader.int32()
-     const hasNotNull = this.reader.int16()
-     return new Parameter(isNonNative, oid, typemod, hasNotNull);
-   }
- 
-   private parseCommandDescriptionMessage(offset: number, length: number, bytes: Buffer) {
-     this.reader.setBuffer(offset, bytes)
-     const tag = this.reader.cstring()
-     const convertedToCopy = this.reader.int16()
-     const convertedStatement = this.reader.cstring()
- 
-     return new CommandDescriptionMessage(length, tag, convertedToCopy, convertedStatement)
-   }
- 
-   private parseDataRowMessage(offset: number, length: number, bytes: Buffer) {
-     this.reader.setBuffer(offset, bytes)
-     const fieldCount = this.reader.int16()
-     const fields: any[] = new Array(fieldCount)
-     for (let i = 0; i < fieldCount; i++) {
-       const len = this.reader.int32()
-       // a -1 for length means the value of the field is null
-       fields[i] = len === -1 ? null : this.reader.string(len)
-     }
-     return new DataRowMessage(length, fields)
-   }
- 
-   private parseParameterStatusMessage(offset: number, length: number, bytes: Buffer) {
-     this.reader.setBuffer(offset, bytes)
-     const name = this.reader.cstring()
-     const value = this.reader.cstring()
-     return new ParameterStatusMessage(length, name, value)
-   }
- 
-   private parseBackendKeyData(offset: number, length: number, bytes: Buffer) {
-     this.reader.setBuffer(offset, bytes)
-     const processID = this.reader.int32()
-     const secretKey = this.reader.int32()
-     return new BackendKeyDataMessage(length, processID, secretKey)
-   }
- 
-   public parseAuthenticationResponse(offset: number, length: number, bytes: Buffer) {
-     this.reader.setBuffer(offset, bytes)
-     const code = this.reader.int32()
-     // TODO(bmc): maybe better types here
-     const message: BackendMessage & any = {
-       name: 'authenticationOk',
-       length,
-     }
- 
-     switch (code) {
-       case 0: // AuthenticationOk
-         break
-       case 3: // AuthenticationCleartextPassword
-         if (message.length === 8) {
-           message.name = 'authenticationCleartextPassword'
-         }
-         break
-       case 5: // AuthenticationMD5Password
-         if (message.length === 12) {
-           message.name = 'authenticationMD5Password'
-           const salt = this.reader.bytes(4)
-           return new AuthenticationMD5Password(length, salt)
-         }
-         break
-       case 65536: // AuthenticationHashPassword
-       case 66048: // AuthenticationHashSHA512Password
-         if(message.length === 32) {
-           const salt = this.reader.bytes(4)
-           const userSaltLen = this.reader.int32()
-           const userSalt = this.reader.bytes(16)
- 
-           return new AuthenticationSHA512Password(length, salt, userSalt)
-         }
-         break
-       case 9: // PasswordExpired
-         return new DatabaseError('Could not authenticate: Password expired.', 0, 'error')
-       default:
-         throw new Error('Unknown authentication request message type ' + code)
-     }
-     return message
-   }
- 
-   private parseErrorMessage(offset: number, length: number, bytes: Buffer, name: MessageName) {
-     this.reader.setBuffer(offset, bytes)
-     const fields: Record<string, string> = {}
-     let fieldType = this.reader.string(1)
-     while (fieldType !== '\0') {
-       fields[fieldType] = this.reader.cstring()
-       fieldType = this.reader.string(1)
-     }
- 
-     const messageValue = fields.M
- 
-     const message =
-       name === 'notice' ? new NoticeMessage(length, messageValue) : new DatabaseError(messageValue, length, name)
- 
-     message.severity = fields.S
-     message.code = fields.C
-     message.detail = fields.D
-     message.hint = fields.H
-     message.position = fields.P
-     message.internalPosition = fields.p
-     message.internalQuery = fields.q
-     message.where = fields.W
-     message.schema = fields.s
-     message.table = fields.t
-     message.column = fields.c
-     message.dataType = fields.d
-     message.constraint = fields.n
-     message.file = fields.F
-     message.line = fields.L
-     message.routine = fields.R
-     return message
-   }
- }
- 
+import { TransformOptions } from 'stream'
+import {
+  Mode,
+  bindComplete,
+  parseComplete,
+  closeComplete,
+  noData,
+  portalSuspended,
+  copyDone,
+  replicationStart,
+  emptyQuery,
+  ReadyForQueryMessage,
+  CommandCompleteMessage,
+  CopyDataMessage,
+  CopyResponse,
+  NotificationResponseMessage,
+  RowDescriptionMessage,
+  ParameterDescriptionMessage,
+  Parameter,
+  CommandDescriptionMessage,
+  Field,
+  DataRowMessage,
+  ParameterStatusMessage,
+  BackendKeyDataMessage,
+  DatabaseError,
+  BackendMessage,
+  MessageName,
+  AuthenticationMD5Password,
+  NoticeMessage,
+  AuthenticationSHA512Password,
+} from './messages'
+import { BufferReader } from './buffer-reader'
+import assert from 'assert'
+
+// every message is prefixed with a single bye
+const CODE_LENGTH = 1
+// every message has an int32 length which includes itself but does
+// NOT include the code in the length
+const LEN_LENGTH = 4
+
+const HEADER_LENGTH = CODE_LENGTH + LEN_LENGTH
+
+export type Packet = {
+  code: number
+  packet: Buffer
+}
+
+const emptyBuffer = Buffer.allocUnsafe(0)
+
+type StreamOptions = TransformOptions & {
+  mode: Mode
+}
+
+const enum MessageCodes {
+  DataRow = 0x44, // D
+  ParseComplete = 0x31, // 1
+  BindComplete = 0x32, // 2
+  CloseComplete = 0x33, // 3
+  CommandComplete = 0x43, // C
+  ReadyForQuery = 0x5a, // Z
+  NoData = 0x6e, // n
+  NotificationResponse = 0x41, // A
+  AuthenticationResponse = 0x52, // R
+  ParameterStatus = 0x53, // S
+  BackendKeyData = 0x4b, // K
+  ErrorMessage = 0x45, // E
+  NoticeMessage = 0x4e, // N
+  RowDescriptionMessage = 0x54, // T
+  ParameterDescriptionMessage = 0x74, // t
+  CommandDescriptionMessage = 0x6d, // m
+  PortalSuspended = 0x73, // s
+  ReplicationStart = 0x57, // W
+  EmptyQuery = 0x49, // I
+  CopyIn = 0x47, // G
+  CopyOut = 0x48, // H
+  CopyDone = 0x63, // c
+  CopyData = 0x64, // d
+}
+
+export type MessageCallback = (msg: BackendMessage) => void
+
+export class Parser {
+  private buffer: Buffer = emptyBuffer
+  private bufferLength: number = 0
+  private bufferOffset: number = 0
+  private reader = new BufferReader()
+  private mode: Mode
+
+  constructor(opts?: StreamOptions) {
+    if (opts?.mode === 'binary') {
+      throw new Error('Binary mode not supported yet')
+    }
+    this.mode = opts?.mode || 'text'
+  }
+
+  public parse(buffer: Buffer, callback: MessageCallback) {
+    this.mergeBuffer(buffer)
+    const bufferFullLength = this.bufferOffset + this.bufferLength
+    let offset = this.bufferOffset
+    while (offset + HEADER_LENGTH <= bufferFullLength) {
+      // code is 1 byte long - it identifies the message type
+      const code = this.buffer[offset]
+      // length is 1 Uint32BE - it is the length of the message EXCLUDING the code
+      const length = this.buffer.readUInt32BE(offset + CODE_LENGTH)
+      const fullMessageLength = CODE_LENGTH + length
+      if (fullMessageLength + offset <= bufferFullLength) {
+        const message = this.handlePacket(offset + HEADER_LENGTH, code, length, this.buffer)
+        callback(message)
+        offset += fullMessageLength
+      } else {
+        break
+      }
+    }
+    if (offset === bufferFullLength) {
+      // No more use for the buffer
+      this.buffer = emptyBuffer
+      this.bufferLength = 0
+      this.bufferOffset = 0
+    } else {
+      // Adjust the cursors of remainingBuffer
+      this.bufferLength = bufferFullLength - offset
+      this.bufferOffset = offset
+    }
+  }
+
+  private mergeBuffer(buffer: Buffer): void {
+    if (this.bufferLength > 0) {
+      const newLength = this.bufferLength + buffer.byteLength
+      const newFullLength = newLength + this.bufferOffset
+      if (newFullLength > this.buffer.byteLength) {
+        // We can't concat the new buffer with the remaining one
+        let newBuffer: Buffer
+        if (newLength <= this.buffer.byteLength && this.bufferOffset >= this.bufferLength) {
+          // We can move the relevant part to the beginning of the buffer instead of allocating a new buffer
+          newBuffer = this.buffer
+        } else {
+          // Allocate a new larger buffer
+          let newBufferLength = this.buffer.byteLength * 2
+          while (newLength >= newBufferLength) {
+            newBufferLength *= 2
+          }
+          newBuffer = Buffer.allocUnsafe(newBufferLength)
+        }
+        // Move the remaining buffer to the new one
+        this.buffer.copy(newBuffer, 0, this.bufferOffset, this.bufferOffset + this.bufferLength)
+        this.buffer = newBuffer
+        this.bufferOffset = 0
+      }
+      // Concat the new buffer with the remaining one
+      buffer.copy(this.buffer, this.bufferOffset + this.bufferLength)
+      this.bufferLength = newLength
+    } else {
+      this.buffer = buffer
+      this.bufferOffset = 0
+      this.bufferLength = buffer.byteLength
+    }
+  }
+
+  private handlePacket(offset: number, code: number, length: number, bytes: Buffer): BackendMessage {
+    switch (code) {
+      case MessageCodes.BindComplete:
+        return bindComplete
+      case MessageCodes.ParseComplete:
+        return parseComplete
+      case MessageCodes.CloseComplete:
+        return closeComplete
+      case MessageCodes.NoData:
+        return noData
+      case MessageCodes.PortalSuspended:
+        return portalSuspended
+      case MessageCodes.CopyDone:
+        return copyDone
+      case MessageCodes.ReplicationStart:
+        return replicationStart
+      case MessageCodes.EmptyQuery:
+        return emptyQuery
+      case MessageCodes.DataRow:
+        return this.parseDataRowMessage(offset, length, bytes)
+      case MessageCodes.CommandComplete:
+        return this.parseCommandCompleteMessage(offset, length, bytes)
+      case MessageCodes.ReadyForQuery:
+        return this.parseReadyForQueryMessage(offset, length, bytes)
+      case MessageCodes.NotificationResponse:
+        return this.parseNotificationMessage(offset, length, bytes)
+      case MessageCodes.AuthenticationResponse:
+        return this.parseAuthenticationResponse(offset, length, bytes)
+      case MessageCodes.ParameterStatus:
+        return this.parseParameterStatusMessage(offset, length, bytes)
+      case MessageCodes.BackendKeyData:
+        return this.parseBackendKeyData(offset, length, bytes)
+      case MessageCodes.ErrorMessage:
+        return this.parseErrorMessage(offset, length, bytes, 'error')
+      case MessageCodes.NoticeMessage:
+        return this.parseErrorMessage(offset, length, bytes, 'notice')
+      case MessageCodes.RowDescriptionMessage:
+        return this.parseRowDescriptionMessage(offset, length, bytes)
+      case MessageCodes.ParameterDescriptionMessage:
+        return this.parseParameterDescriptionMessage(offset, length, bytes)
+      case MessageCodes.CommandDescriptionMessage:
+        return this.parseCommandDescriptionMessage(offset, length, bytes)
+      case MessageCodes.CopyIn:
+        return this.parseCopyInMessage(offset, length, bytes)
+      case MessageCodes.CopyOut:
+        return this.parseCopyOutMessage(offset, length, bytes)
+      case MessageCodes.CopyData:
+        return this.parseCopyData(offset, length, bytes)
+      default:
+        assert.fail(`unknown message code: ${code.toString(16)}`)
+    }
+  }
+
+  private parseReadyForQueryMessage(offset: number, length: number, bytes: Buffer) {
+    this.reader.setBuffer(offset, bytes)
+    const status = this.reader.string(1)
+    return new ReadyForQueryMessage(length, status)
+  }
+
+  private parseCommandCompleteMessage(offset: number, length: number, bytes: Buffer) {
+    this.reader.setBuffer(offset, bytes)
+    const text = this.reader.cstring()
+    return new CommandCompleteMessage(length, text)
+  }
+
+  private parseCopyData(offset: number, length: number, bytes: Buffer) {
+    const chunk = bytes.slice(offset, offset + (length - 4))
+    return new CopyDataMessage(length, chunk)
+  }
+
+  private parseCopyInMessage(offset: number, length: number, bytes: Buffer) {
+    return this.parseCopyMessage(offset, length, bytes, 'copyInResponse')
+  }
+
+  private parseCopyOutMessage(offset: number, length: number, bytes: Buffer) {
+    return this.parseCopyMessage(offset, length, bytes, 'copyOutResponse')
+  }
+
+  private parseCopyMessage(offset: number, length: number, bytes: Buffer, messageName: MessageName) {
+    this.reader.setBuffer(offset, bytes)
+    const isBinary = this.reader.byte() !== 0
+    const columnCount = this.reader.int16()
+    const message = new CopyResponse(length, messageName, isBinary, columnCount)
+    for (let i = 0; i < columnCount; i++) {
+      message.columnTypes[i] = this.reader.int16()
+    }
+    return message
+  }
+
+  private parseNotificationMessage(offset: number, length: number, bytes: Buffer) {
+    this.reader.setBuffer(offset, bytes)
+    const processId = this.reader.int32()
+    const channel = this.reader.cstring()
+    const payload = this.reader.cstring()
+    return new NotificationResponseMessage(length, processId, channel, payload)
+  }
+
+  private parseRowDescriptionMessage(offset: number, length: number, bytes: Buffer) {
+    this.reader.setBuffer(offset, bytes)
+    const fieldCount = this.reader.int16()
+    const message = new RowDescriptionMessage(length, fieldCount)
+    if (fieldCount === 0) {
+      return message
+    }
+    const nonNativeTypeCount = this.reader.int32()
+    if (nonNativeTypeCount > 0) {
+      throw new Error("Non native types are not yet supported")
+    }
+    for (let i = 0; i < fieldCount; i++) {
+      message.fields[i] = this.parseField()
+    }
+    return message
+  }
+
+  private parseField(): Field {
+    const name = this.reader.cstring()
+    const tableID = this.reader.uint64()
+    const schemaName = this.reader.cstring()
+    const tableName = this.reader.cstring()
+    const columnID = this.reader.int16()
+    //const parentTypeID = this.reader.int16() // breadcrumb for complex types
+    const isNonNative = this.reader.bytes(1)
+    if (isNonNative[0] == 1) {
+      throw new Error("Non native types are not yet supported")
+    }
+    const dataTypeID = this.reader.int32() // for non native types this would be the index into the type mapping pool
+    const dataTypeSize = this.reader.int16()
+    const allowsNull = this.reader.int16()
+    const isIdentity = this.reader.int16()
+    const dataTypeModifier = this.reader.int32()
+    const mode = this.reader.int16() === 0 ? 'text' : 'binary'
+    return new Field(name, tableID, schemaName, tableName, columnID, dataTypeID, dataTypeSize, allowsNull, isIdentity, dataTypeModifier, mode)
+  }
+
+  private parseParameterDescriptionMessage(offset: number, length: number, bytes: Buffer) {
+    this.reader.setBuffer(offset, bytes)
+    const parameterCount = this.reader.int16()
+    const message = new ParameterDescriptionMessage(length, parameterCount)
+    if (parameterCount === 0) {
+      return message
+    }
+    const nonNativeTypeCount = this.reader.int32() 
+    if (nonNativeTypeCount > 0 ) {
+      throw new Error("Non native types are not yet supported")
+    }
+    for (let i = 0; i < parameterCount; i++) {
+      message.parameters[i] = this.parseParameter()
+    }
+    return message
+  }
+
+  private parseParameter(): Parameter {
+    const isNonNative = this.reader.byte() !== 0
+    if (isNonNative) { // should have been caught already, but just in case
+      throw new Error("Non native types are not yet supported")
+    }
+    const oid = this.reader.int32()
+    const typemod = this.reader.int32()
+    const hasNotNull = this.reader.int16()
+    return new Parameter(isNonNative, oid, typemod, hasNotNull);
+  }
+
+  private parseCommandDescriptionMessage(offset: number, length: number, bytes: Buffer) {
+    this.reader.setBuffer(offset, bytes)
+    const tag = this.reader.cstring()
+    const convertedToCopy = this.reader.int16()
+    const convertedStatement = this.reader.cstring()
+
+    return new CommandDescriptionMessage(length, tag, convertedToCopy, convertedStatement)
+  }
+
+  private parseDataRowMessage(offset: number, length: number, bytes: Buffer) {
+    this.reader.setBuffer(offset, bytes)
+    const fieldCount = this.reader.int16()
+    const fields: any[] = new Array(fieldCount)
+    for (let i = 0; i < fieldCount; i++) {
+      const len = this.reader.int32()
+      // a -1 for length means the value of the field is null
+      fields[i] = len === -1 ? null : this.reader.string(len)
+    }
+    return new DataRowMessage(length, fields)
+  }
+
+  private parseParameterStatusMessage(offset: number, length: number, bytes: Buffer) {
+    this.reader.setBuffer(offset, bytes)
+    const name = this.reader.cstring()
+    const value = this.reader.cstring()
+    return new ParameterStatusMessage(length, name, value)
+  }
+
+  private parseBackendKeyData(offset: number, length: number, bytes: Buffer) {
+    this.reader.setBuffer(offset, bytes)
+    const processID = this.reader.int32()
+    const secretKey = this.reader.int32()
+    return new BackendKeyDataMessage(length, processID, secretKey)
+  }
+
+  public parseAuthenticationResponse(offset: number, length: number, bytes: Buffer) {
+    this.reader.setBuffer(offset, bytes)
+    const code = this.reader.int32()
+    // TODO(bmc): maybe better types here
+    const message: BackendMessage & any = {
+      name: 'authenticationOk',
+      length,
+    }
+
+    switch (code) {
+      case 0: // AuthenticationOk
+        break
+      case 3: // AuthenticationCleartextPassword
+        if (message.length === 8) {
+          message.name = 'authenticationCleartextPassword'
+        }
+        break
+      case 5: // AuthenticationMD5Password
+        if (message.length === 12) {
+          message.name = 'authenticationMD5Password'
+          const salt = this.reader.bytes(4)
+          return new AuthenticationMD5Password(length, salt)
+        }
+        break
+      case 65536: // AuthenticationHashPassword
+      case 66048: // AuthenticationHashSHA512Password
+        if(message.length === 32) {
+          const salt = this.reader.bytes(4)
+          const userSaltLen = this.reader.int32()
+          const userSalt = this.reader.bytes(16)
+
+          return new AuthenticationSHA512Password(length, salt, userSalt)
+        }
+        break
+      case 9: // PasswordExpired
+        return new DatabaseError('Could not authenticate: Password expired.', 0, 'error')
+      default:
+        throw new Error('Unknown authentication request message type ' + code)
+    }
+    return message
+  }
+
+  private parseErrorMessage(offset: number, length: number, bytes: Buffer, name: MessageName) {
+    this.reader.setBuffer(offset, bytes)
+    const fields: Record<string, string> = {}
+    let fieldType = this.reader.string(1)
+    while (fieldType !== '\0') {
+      fields[fieldType] = this.reader.cstring()
+      fieldType = this.reader.string(1)
+    }
+
+    const messageValue = fields.M
+
+    const message =
+      name === 'notice' ? new NoticeMessage(length, messageValue) : new DatabaseError(messageValue, length, name)
+
+    message.severity = fields.S
+    message.code = fields.C
+    message.detail = fields.D
+    message.hint = fields.H
+    message.position = fields.P
+    message.internalPosition = fields.p
+    message.internalQuery = fields.q
+    message.where = fields.W
+    message.schema = fields.s
+    message.table = fields.t
+    message.column = fields.c
+    message.dataType = fields.d
+    message.constraint = fields.n
+    message.file = fields.F
+    message.line = fields.L
+    message.routine = fields.R
+    return message
+  }
+}

--- a/packages/vertica-nodejs/test/integration/client/query-column-names-tests.js
+++ b/packages/vertica-nodejs/test/integration/client/query-column-names-tests.js
@@ -2,16 +2,38 @@
 var helper = require('../test-helper')
 var vertica = helper.vertica
 
-new helper.Suite().test('support for complex column names', function () {
+var suite = new helper.Suite()
+
+suite.test('support for complex column names', function () {
   const pool = new vertica.Pool()
   pool.connect(
     assert.success(function (client, done) {
-      client.query('CREATE TEMP TABLE t ( "complex\'\'column" TEXT )')
+      client.query('CREATE LOCAL TEMP TABLE t ( "complex\'\'column" VARCHAR )')
       client.query(
         'SELECT * FROM t',
         assert.success(function (res) {
           done()
           assert.strictEqual(res.fields[0].name, "complex''column")
+          pool.end()
+        })
+      )
+    })
+  )
+})
+
+suite.test('column names are returned correctly', function() {
+  const pool = new vertica.Pool()
+  pool.connect(
+    assert.success(function (client, done) {
+      client.query('CREATE LOCAL TEMP TABLE d ( foobar VARCHAR, abcd INTEGER )')
+      client.query("INSERT INTO d VALUES ( 'wow', 9 )")
+      client.query(
+        'SELECT * FROM d',
+        assert.success(function (res) {
+          done()
+          console.log(res)
+          assert.strictEqual(res.fields[0].name, 'foobar')
+          assert.strictEqual(res.fields[1].name, 'abcd')
           pool.end()
         })
       )


### PR DESCRIPTION
Copied from Danny's PR:
"There were issues with parsing rowDescription messages. We were trying to parse a field for the attribute number of the parent type for complex types. That doesn't apply here and shouldn't be parsed. In addition I added more information that was being parsed in the RowDescriptionMessage to the Field type."

A regression test is also added.