### PR TITLE
Send sync message after error in extended query flow

### DIFF
--- a/packages/vertica-nodejs/lib/query.js
+++ b/packages/vertica-nodejs/lib/query.js
@@ -138,6 +138,7 @@ class Query extends EventEmitter {
 
   handleError(err, connection) {
     // need to sync after error during a prepared statement
+    connection.sync()
     if (this._canceledDueToError) {
       err = this._canceledDueToError
       this._canceledDueToError = false


### PR DESCRIPTION
This should fix some cases where queries sent after a prepared statement are not run. The tests in error-handling.js integration test suite will cover this once.