### PR TITLE
Update package versions to 0.9.0-pre.6

### DIFF
--- a/packages/v-connection-string/package.json
+++ b/packages/v-connection-string/package.json
@@ -1,6 +1,6 @@
 {
   "name": "v-connection-string",
-  "version": "0.9.0-pre.5",
+  "version": "0.9.0-pre.6",
   "description": "Functions for dealing with a Vertica connection string",
   "main": "./index.js",
   "types": "./index.d.ts",

--- a/packages/v-pool/package.json
+++ b/packages/v-pool/package.json
@@ -1,6 +1,6 @@
 {
   "name": "v-pool",
-  "version": "0.9.0-pre.5",
+  "version": "0.9.0-pre.6",
   "description": "Connection pool for Vertica",
   "main": "index.js",
   "directories": {
@@ -36,6 +36,6 @@
     "pg-cursor": "^1.3.0"
   },
   "peerDependencies": {
-    "vertica-nodejs": "0.9.0-pre.5"
+    "vertica-nodejs": "0.9.0-pre.6"
   }
 }

--- a/packages/v-protocol/package.json
+++ b/packages/v-protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "v-protocol",
-  "version": "0.9.0-pre.5",
+  "version": "0.9.0-pre.6",
   "description": "The Vertica client/server binary protocol, implemented in TypeScript",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/vertica-nodejs/package.json
+++ b/packages/vertica-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vertica-nodejs",
-  "version": "0.9.0-pre.5",
+  "version": "0.9.0-pre.6",
   "description": "Vertica client - pure javascript & libpq with the same API",
   "keywords": [
     "database",
@@ -28,9 +28,9 @@
   "dependencies": {
     "buffer-writer": "2.0.0",
     "packet-reader": "1.0.0",
-    "v-connection-string": "0.9.0-pre.5",
-    "v-pool": "0.9.0-pre.5",
-    "v-protocol": "0.9.0-pre.5",
+    "v-connection-string": "0.9.0-pre.6",
+    "v-pool": "0.9.0-pre.6",
+    "v-protocol": "0.9.0-pre.6",
     "pg-types": "^2.1.0",
     "pgpass": "1.x"
   },


### PR DESCRIPTION
This PR updates the package versions to 0.9.0-pre.6 in preparation for our next release. We should not publish the next release until #28 and #27 have been merged.