### PR TITLE
Ensure publish script removes node_modules and runs yarn from root directory

### DIFF
--- a/packages/publish_npm.sh
+++ b/packages/publish_npm.sh
@@ -45,7 +45,8 @@ read -p "Enter [yes] to publish [no] " shouldContinue
 shopt -s nocasematch
 if [[ ${shouldContinue} == "yes" ]]; then
     echo "Building vertica-nodejs.."
-    yarn
+    rm -rf ../node_modules
+    (cd .. && yarn)
     echo "Publishing to Node Package Manager.."
     npm publish ./v-connection-string $dry_run_arg
     npm publish ./v-pool $dry_run_arg

--- a/packages/publish_npm.sh
+++ b/packages/publish_npm.sh
@@ -44,8 +44,11 @@ read -p "Enter [yes] to publish [no] " shouldContinue
 # Therefore, any changes to this logic should be tested on linux and macos.
 shopt -s nocasematch
 if [[ ${shouldContinue} == "yes" ]]; then
-    echo "Building vertica-nodejs.."
+    echo "Cleaning up generated files.."
+    # Removing node_modules ensures that we don't use old compiled javascript files
     rm -rf ../node_modules
+    echo "Building vertica-nodejs.."
+    # This builds the project, which compiles the typescript into javascript files
     (cd .. && yarn)
     echo "Publishing to Node Package Manager.."
     npm publish ./v-connection-string $dry_run_arg


### PR DESCRIPTION
This PR adjusts the publish script so that we are guaranteed to use the newest compiled typescript when publishing a release.