### PR TITLE
Resolved extended query protocol sync issue with error handling

### DIFF
--- a/packages/vertica-nodejs/lib/query.js
+++ b/packages/vertica-nodejs/lib/query.js
@@ -138,7 +138,6 @@ class Query extends EventEmitter {
 
   handleError(err, connection) {
     // need to sync after error during a prepared statement
-    connection.sync()
     if (this._canceledDueToError) {
       err = this._canceledDueToError
       this._canceledDueToError = false
@@ -148,6 +147,7 @@ class Query extends EventEmitter {
     if (this.callback) {
       return this.callback(err)
     }
+    connection.sync()
     this.emit('error', err)
   }
 
@@ -188,7 +188,6 @@ class Query extends EventEmitter {
     //do nothing, vertica doesn't support result-row count limit
   }
 
-  // http://developer.postgresql.org/pgdocs/postgres/protocol-flow.html#PROTOCOL-FLOW-EXT-QUERY
   prepare(connection) {
     // prepared statements need sync to be called after each command
     // complete or when an error is encountered


### PR DESCRIPTION
Moved the call to sync to allow the rest of the error handling logic to occur first. This also resolves some regressions in prepared statement tests. Fixed some syntax problems with prepared statements. Used local temp tables where applicable. connection async changes we've made prior required one test to be asynchronous as well. Modified some error asserts to be more specific.