### PR TITLE
Fix quick-disconnect-tests.js

### DIFF
--- a/packages/vertica-nodejs/lib/client.js
+++ b/packages/vertica-nodejs/lib/client.js
@@ -698,7 +698,7 @@ class Client extends EventEmitter {
     this._ending = true
 
     // if we have never connected, then end is a noop, callback immediately
-    if (!this.connection._connecting) {
+    if (!this._connecting) {
       if (cb) {
         cb()
       } else {

--- a/packages/vertica-nodejs/lib/client.js
+++ b/packages/vertica-nodejs/lib/client.js
@@ -698,7 +698,7 @@ class Client extends EventEmitter {
     this._ending = true
 
     // if we have never connected, then end is a noop, callback immediately
-    if (!this._connecting) {
+    if (!this._connecting && !this.connection._connecting) {
       if (cb) {
         cb()
       } else {

--- a/packages/vertica-nodejs/test/integration/client/quick-disconnect-tests.js
+++ b/packages/vertica-nodejs/test/integration/client/quick-disconnect-tests.js
@@ -1,9 +1,6 @@
 'use strict'
-// test for issue #320
-//
 var helper = require('./test-helper')
 
-/*var client = new helper.vertica.Client(helper.config)
+var client = new helper.vertica.Client(helper.config)
 client.connect()
 client.end()
-*/


### PR DESCRIPTION
This PR fixes quick-disconnect-tests.js so it no longer hangs. From running other tests, it seems like this doesn't cause any regressions.