### PR TITLE
Update logic around error handling with prepared statements

### DIFF
--- a/packages/vertica-nodejs/lib/client.js
+++ b/packages/vertica-nodejs/lib/client.js
@@ -591,7 +591,6 @@ class Client extends EventEmitter {
         if (queryError) {
           process.nextTick(() => {
             this.activeQuery.handleError(queryError, this.connection)
-            this.readyForQuery = true
             this._pulseQueryQueue()
           })
         }


### PR DESCRIPTION
There was an issue where we couldn't use callbacks and call a second query after a prepared statement failed. This is because sync() was never called in this case. This PR does two things:
- Remove built-in ready for query flag in internal error cases and always sync after an error
- Add new flag to make sure we only call the callback once in an error case