### PR TITLE
Fixed unit tests related to old ssl connection params

### DIFF
--- a/packages/v-connection-string/index.js
+++ b/packages/v-connection-string/index.js
@@ -42,7 +42,7 @@ function parse(str) {
   }
 
   // if the tls mode specified in the connection string is an invalid option, use the default - disable.
-  if (!['require', 'verify-ca', 'verify-full'].includes(config.tls_mode)) {
+  if (config.tls_mode && !['require', 'verify-ca', 'verify-full'].includes(config.tls_mode)) {
     config.tls_mode = 'disable'
   }
   

--- a/packages/vertica-nodejs/test/unit/connection-parameters/environment-variable-tests.js
+++ b/packages/vertica-nodejs/test/unit/connection-parameters/environment-variable-tests.js
@@ -69,58 +69,32 @@ suite.test('connection string parsing', function () {
   assert.equal(subject.database, 'lala', 'string database')
 })
 
-suite.test('connection string parsing - ssl', function () {
+suite.test('connection string parsing - tls_mode', function () {
   // clear process.env
   clearEnv()
 
-  var string = 'postgres://brian:pw@boom:381/lala?ssl=true'
+  var string = 'postgres://brian:pw@boom:381/lala?tls_mode=require'
   var subject = new ConnectionParameters(string)
-  assert.equal(subject.ssl, true, 'ssl')
+  assert.equal(subject.tls_mode, 'require')
 
-  string = 'postgres://brian:pw@boom:381/lala?ssl=1'
+  string = 'postgres://brian:pw@boom:381/lala?tls_mode=disable'
   subject = new ConnectionParameters(string)
-  assert.equal(subject.ssl, true, 'ssl')
-
-  string = 'postgres://brian:pw@boom:381/lala?other&ssl=true'
-  subject = new ConnectionParameters(string)
-  assert.equal(subject.ssl, true, 'ssl')
-
-  string = 'postgres://brian:pw@boom:381/lala?ssl=0'
-  subject = new ConnectionParameters(string)
-  assert.equal(!!subject.ssl, false, 'ssl')
+  assert.equal(subject.tls_mode, 'disable')
 
   string = 'postgres://brian:pw@boom:381/lala'
   subject = new ConnectionParameters(string)
-  assert.equal(!!subject.ssl, false, 'ssl')
+  assert.equal(subject.tls_mode, 'disable')
 
-  string = 'postgres://brian:pw@boom:381/lala?ssl=no-verify'
+  string = 'postgres://brian:pw@boom:381/lala?tls_mode=verify-ca'
   subject = new ConnectionParameters(string)
-  assert.deepStrictEqual(subject.ssl, { rejectUnauthorized: false }, 'ssl')
+  assert.equal(subject.tls_mode, 'verify-ca')
 })
 
-suite.test('ssl is false by default', function () {
+suite.test('tls mode is disable by default', function () {
   clearEnv()
   var subject = new ConnectionParameters()
-  assert.equal(subject.ssl, false)
+  assert.equal(subject.tls_mode, 'disable')
 })
-
-var testVal = function (mode, expected) {
-  suite.test('ssl is ' + expected + ' when $PGSSLMODE=' + mode, function () {
-    clearEnv()
-    process.env.PGSSLMODE = mode
-    var subject = new ConnectionParameters()
-    assert.deepStrictEqual(subject.ssl, expected)
-  })
-}
-
-testVal('', false)
-testVal('disable', false)
-testVal('allow', false)
-testVal('prefer', true)
-testVal('require', true)
-testVal('verify-ca', true)
-testVal('verify-full', true)
-testVal('no-verify', { rejectUnauthorized: false })
 
 // restore process.env
 for (var key in realEnv) {


### PR DESCRIPTION
Updates old unit tests still using ssl connection property

Also fixes a bug where tls_mode would always be set to disable if both a connection string and a config object were provided, and only the config object set the tls_mode to something other than disable. 