### PR TITLE
Fix transaction-tests.js

### DIFF
--- a/packages/vertica-nodejs/test/integration/client/transaction-tests.js
+++ b/packages/vertica-nodejs/test/integration/client/transaction-tests.js
@@ -47,7 +47,7 @@ client.connect(
     })
 
     suite.test('rollback', (done) => {
-      client.query('rollback; COMMIT;', done)
+      client.query('rollback', done)
     })
 
     suite.test('name should not exist in the database', function (done) {

--- a/packages/vertica-nodejs/test/integration/client/transaction-tests.js
+++ b/packages/vertica-nodejs/test/integration/client/transaction-tests.js
@@ -17,8 +17,6 @@ client.connect(
       client.query(
         getZed,
         assert.calls(function (err, result) {
-          console.log("inside assert")
-          console.log(err)
           assert(!err)
           assert.empty(result.rows)
           done()
@@ -57,7 +55,6 @@ client.connect(
         getZed,
         assert.calls(function (err, result) {
           assert(!err)
-          console.log(result.rows)
           assert.empty(result.rows)
           client.end(done)
         })

--- a/packages/vertica-nodejs/test/integration/client/transaction-tests.js
+++ b/packages/vertica-nodejs/test/integration/client/transaction-tests.js
@@ -17,6 +17,8 @@ client.connect(
       client.query(
         getZed,
         assert.calls(function (err, result) {
+          console.log("inside assert")
+          console.log(err)
           assert(!err)
           assert.empty(result.rows)
           done()
@@ -30,7 +32,6 @@ client.connect(
         ['Zed', 270],
         assert.calls(function (err, result) {
           assert(!err)
-          client.query('COMMIT;')
           done()
         })
       )
@@ -48,7 +49,7 @@ client.connect(
     })
 
     suite.test('rollback', (done) => {
-      client.query('rollback', done)
+      client.query('rollback; COMMIT;', done)
     })
 
     suite.test('name should not exist in the database', function (done) {
@@ -56,6 +57,7 @@ client.connect(
         getZed,
         assert.calls(function (err, result) {
           assert(!err)
+          console.log(result.rows)
           assert.empty(result.rows)
           client.end(done)
         })


### PR DESCRIPTION
This change fixes the transaction-tests.js integration test suite. Note that this test suite requires the create-test-tables.js script to be run first. The COMMIT that was removed in this PR was mistakenly added at some point and was never in the original tests in node-postgres.