### PR TITLE
Update dev containers to use Vertica

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get update \
     && curl -sS https://dl.yarnpkg.com/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/pubkey.gpg | apt-key add - 2>/dev/null \
     && echo "deb https://dl.yarnpkg.com/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
     && apt-get update \
-    && apt-get -y install --no-install-recommends yarn tmux locales postgresql \
+    && apt-get -y install --no-install-recommends yarn tmux locales \
     #
     # Install eslint globally
     && npm install -g eslint \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 // If you want to run as a non-root user in the container, see .devcontainer/docker-compose.yml.
 {
-	"name": "Node.js 12 & Postgres",
+	"name": "Node.js 12 & Vertica",
 	"dockerComposeFile": "docker-compose.yml",
 	"service": "web",
 	"workspaceFolder": "/workspace",
@@ -18,7 +18,7 @@
 	// "shutdownAction": "none",
 
 	// Uncomment the next line to run commands after the container is created.
-	// "postCreateCommand": "npm install",
+	"postCreateCommand": "yarn && yarn lerna bootstrap",
 
 	// Uncomment the next line to have VS Code connect as an existing non-root user in the container. See
 	// https://aka.ms/vscode-remote/containers/non-root for details on adding a non-root user if none exist.

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -12,36 +12,24 @@ services:
     # you may need to update USER_UID and USER_GID in .devcontainer/Dockerfile to match your
     # user if not 1000. See https://aka.ms/vscode-remote/containers/non-root for details.
     # user: node
-
-    build: 
+    build:
       context: .
       dockerfile: Dockerfile
-    
     volumes:
       - ..:/workspace:cached
-
     environment:
-      PGPASSWORD: pass
-      PGUSER: user
-      PGDATABASE: data
-      PGHOST: db
-      # set this to true in the development environment until I can get SSL setup on the 
-      # docker postgres instance
-      PGTESTNOSSL: true
-      
+      - V_HOST=db
+      - V_PORT=5433
+      - V_DATABASE=VMart
+      - V_USER=dbadmin
+      - V_PASSWORD=
     # Overrides default command so things don't shut down after the process ends.
     command: sleep infinity
-
     links:
       - db
 
   db:
-    image: postgres
+    image: vertica/vertica-ce:latest
     restart: unless-stopped
-    ports: 
-      - 5432:5432
-    environment:
-      POSTGRES_PASSWORD: pass
-      POSTGRES_USER: user
-      POSTGRES_DB: data
- 
+    ports:
+      - "5433:5433"

--- a/README.md
+++ b/README.md
@@ -68,8 +68,10 @@ Outside contributions to this project are greatly appreciated. Following standar
 1. Clone the repo
 2. From your workspace root run `yarn` and then `yarn lerna bootstrap`
 3. Ensure you have a Vertica instance running with 
-4. Ensure you have the proper environment variables configured for connecting to the instance (V_HOST, V_PORT, V_USER, V_PASSWORD, V_DATABASE, V_BACKUP_SERVER_NODE)
-5. Run `yarn test` to run all the tests, or run `yarn test` from within an individual package to only run that package's tests. 
+4. Ensure you have the proper environment variables configured for connecting to the instance (`V_HOST`, `V_PORT`, `V_USER`, `V_PASSWORD`, `V_DATABASE`, `V_BACKUP_SERVER_NODE`)
+5. Run `yarn test` to run all the tests, or run `yarn test` from within an individual package to only run that package's tests
+
+If using VS Code, you can install the `Remote - Containers` extension and it will use the configuration under the `.devcontainer` folder to automatically create dev containers, including Vertica.  See [here](https://code.visualstudio.com/docs/remote/containers) for more information on developing in containers using VS Code.  This process will complete steps 2 to 4 above.
 
 ## Troubleshooting and FAQ
 

--- a/packages/v-connection-string/README.md
+++ b/packages/v-connection-string/README.md
@@ -67,8 +67,10 @@ See the [examples directory](https://github.com/vertica/vertica-nodejs/tree/mast
 1. Clone the repo
 2. From your workspace root run `yarn` and then `yarn lerna bootstrap`
 3. Ensure you have a Vertica instance running with 
-4. Ensure you have the proper environment variables configured for connecting to the instance (V_HOST, V_PORT, V_USER, V_PASSWORD, V_DATABASE, V_BACKUP_SERVER_NODE)
-5. Run `yarn test` to run all the tests, or run `yarn test` from within an individual package to only run that package's tests. 
+4. Ensure you have the proper environment variables configured for connecting to the instance (`V_HOST`, `V_PORT`, `V_USER`, `V_PASSWORD`, `V_DATABASE`, `V_BACKUP_SERVER_NODE`)
+5. Run `yarn test` to run all the tests, or run `yarn test` from within an individual package to only run that package's tests
+
+If using VS Code, you can install the `Remote - Containers` extension and it will use the configuration under the `.devcontainer` folder to automatically create dev containers, including Vertica.  See [here](https://code.visualstudio.com/docs/remote/containers) for more information on developing in containers using VS Code.  This process will complete steps 2 to 4 above.
 
 ## Troubleshooting and FAQ
 

--- a/packages/v-pool/README.md
+++ b/packages/v-pool/README.md
@@ -57,8 +57,10 @@ See the [examples directory](https://github.com/vertica/vertica-nodejs/tree/mast
 1. Clone the repo
 2. From your workspace root run `yarn` and then `yarn lerna bootstrap`
 3. Ensure you have a Vertica instance running with 
-4. Ensure you have the proper environment variables configured for connecting to the instance (V_HOST, V_PORT, V_USER, V_PASSWORD, V_DATABASE, V_BACKUP_SERVER_NODE)
-5. Run `yarn test` to run all the tests, or run `yarn test` from within an individual package to only run that package's tests. 
+4. Ensure you have the proper environment variables configured for connecting to the instance (`V_HOST`, `V_PORT`, `V_USER`, `V_PASSWORD`, `V_DATABASE`, `V_BACKUP_SERVER_NODE`)
+5. Run `yarn test` to run all the tests, or run `yarn test` from within an individual package to only run that package's tests
+
+If using VS Code, you can install the `Remote - Containers` extension and it will use the configuration under the `.devcontainer` folder to automatically create dev containers, including Vertica.  See [here](https://code.visualstudio.com/docs/remote/containers) for more information on developing in containers using VS Code.  This process will complete steps 2 to 4 above.
 
 ## Troubleshooting and FAQ
 

--- a/packages/v-protocol/README.md
+++ b/packages/v-protocol/README.md
@@ -55,8 +55,10 @@ See the [examples directory](https://github.com/vertica/vertica-nodejs/tree/mast
 1. Clone the repo
 2. From your workspace root run `yarn` and then `yarn lerna bootstrap`
 3. Ensure you have a Vertica instance running with 
-4. Ensure you have the proper environment variables configured for connecting to the instance (V_HOST, V_PORT, V_USER, V_PASSWORD, V_DATABASE, V_BACKUP_SERVER_NODE)
-5. Run `yarn test` to run all the tests, or run `yarn test` from within an individual package to only run that package's tests. 
+4. Ensure you have the proper environment variables configured for connecting to the instance (`V_HOST`, `V_PORT`, `V_USER`, `V_PASSWORD`, `V_DATABASE`, `V_BACKUP_SERVER_NODE`)
+5. Run `yarn test` to run all the tests, or run `yarn test` from within an individual package to only run that package's tests
+
+If using VS Code, you can install the `Remote - Containers` extension and it will use the configuration under the `.devcontainer` folder to automatically create dev containers, including Vertica.  See [here](https://code.visualstudio.com/docs/remote/containers) for more information on developing in containers using VS Code.  This process will complete steps 2 to 4 above.
 
 ## Troubleshooting and FAQ
 

--- a/packages/vertica-nodejs/README.md
+++ b/packages/vertica-nodejs/README.md
@@ -55,8 +55,10 @@ See the [examples directory](https://github.com/vertica/vertica-nodejs/tree/mast
 1. Clone the repo
 2. From your workspace root run `yarn` and then `yarn lerna bootstrap`
 3. Ensure you have a Vertica instance running with 
-4. Ensure you have the proper environment variables configured for connecting to the instance (V_HOST, V_PORT, V_USER, V_PASSWORD, V_DATABASE, V_BACKUP_SERVER_NODE)
-5. Run `yarn test` to run all the tests, or run `yarn test` from within an individual package to only run that package's tests. 
+4. Ensure you have the proper environment variables configured for connecting to the instance (`V_HOST`, `V_PORT`, `V_USER`, `V_PASSWORD`, `V_DATABASE`, `V_BACKUP_SERVER_NODE`)
+5. Run `yarn test` to run all the tests, or run `yarn test` from within an individual package to only run that package's tests
+
+If using VS Code, you can install the `Remote - Containers` extension and it will use the configuration under the `.devcontainer` folder to automatically create dev containers, including Vertica.  See [here](https://code.visualstudio.com/docs/remote/containers) for more information on developing in containers using VS Code.  This process will complete steps 2 to 4 above.
 
 ## Troubleshooting and FAQ
 


### PR DESCRIPTION
# Summary of Changes
- Updated the dev containers (under .devcontainer) to deploy Vertica instead of PostgeSQL
- Added instructions on how to use dev containers in VS Code

By installing the Remote - Containers extension then opening the project in VS Code the dev containers are automatically created and the workspace is configured.  From there I can simply run `yarn test` to execute the tests in the IDE.

We can always change the `docker-compose.yml` and `Dockerfile` if we want to up the minimum supported version of Node and other packages.