### PR TITLE
Only call sync for prepared statements remove sync message for internal errors

### DIFF
--- a/packages/vertica-nodejs/lib/client.js
+++ b/packages/vertica-nodejs/lib/client.js
@@ -379,6 +379,7 @@ class Client extends EventEmitter {
         // remove callback for proper error handling
         // after the connect event
         this._connectionCallback = null
+        
       }
       this.emit('connect')
     }
@@ -590,7 +591,8 @@ class Client extends EventEmitter {
         const queryError = this.activeQuery.submit(this.connection)
         if (queryError) {
           process.nextTick(() => {
-            this.activeQuery.handleError(queryError, this.connection)
+            this.activeQuery.handleError(queryError, this.connection, true)
+            this.readyForQuery = true
             this._pulseQueryQueue()
           })
         }

--- a/packages/vertica-nodejs/lib/query.js
+++ b/packages/vertica-nodejs/lib/query.js
@@ -137,7 +137,7 @@ class Query extends EventEmitter {
     }
   }
 
-  handleError(err, connection) {
+  handleError(err, connection, internalError = false) {
     // need to sync after error during a prepared statement
     if (this._canceledDueToError) {
       err = this._canceledDueToError
@@ -146,7 +146,9 @@ class Query extends EventEmitter {
     // if callback supplied do not emit error event as uncaught error
     // events will bubble up to node process
     this._activeError = true
-    connection.sync()
+    if (this.requiresPreparation() && !internalError) {
+      connection.sync()
+    }
     if (this.callback) {
       return this.callback(err)
     }


### PR DESCRIPTION
The extra sync call previously added was only needed for prepared statements, and was being called in all cases instead, resulting in receiving two readyForQuery messages.

This PR also has the sync only sent for server errors now, and handles all internal driver errors by setting the readyForQuery flag instead.