### PR TITLE
Add ENABLED to primary key constraint in test case and modify to chec…

### DIFF
--- a/packages/vertica-nodejs/test/integration/client/query-error-handling-tests.js
+++ b/packages/vertica-nodejs/test/integration/client/query-error-handling-tests.js
@@ -22,16 +22,12 @@ test('constraint error fields', function () {
   var client = new Client(helper.args)
   client.connect(
     assert.success(function () {
-        client.query('CREATE LOCAL TEMP TABLE constraint_err_test(a int PRIMARY KEY)')
+        client.query('CREATE LOCAL TEMP TABLE constraint_err_test(a int PRIMARY KEY ENABLED)')
         client.query('INSERT INTO constraint_err_test(a) VALUES (1)')
         client.query('INSERT INTO constraint_err_test(a) VALUES (1)', function (err) {
-          if (!helper.config.native) {
-            assert(err instanceof DatabaseError)
-          }
+          assert(err instanceof DatabaseError)
           assert.equal(err.severity, 'ERROR')
           assert.equal(err.code, '23505')
-          assert.equal(err.table, 'constraint_err_test')
-          assert.equal(err.constraint, 'constraint_err_test_pkey')
           return client.end()
         })
     })


### PR DESCRIPTION
Vertica, by default, seems to not enable primary key constraints, this PR adjusts this test case for this, as well as not checking for error information not returned by Vertica.