### PR TITLE
Add check for case causing sizing test to take too long

### DIFF
--- a/packages/v-pool/test/sizing.js
+++ b/packages/v-pool/test/sizing.js
@@ -60,6 +60,14 @@ describe('pool size of 1', () => {
 
       const pool = new Pool({ max: 1 })
 
+      var result = yield pool.query("SELECT COUNT(*) FROM query_requests")
+      var queryRequestsRowCount = result.rows[0].COUNT
+
+      if(queryRequestsRowCount > 4000){
+        console.log(" -- Skipping test because query_requests table is too large")
+        return yield pool.end()
+      }
+
       const queryText = "SELECT COUNT(*) as counts FROM query_requests WHERE is_executing='t' AND request LIKE ?"
       const queryTextMatch = "SELECT COUNT(*) as counts FROM query_requests WHERE is_executing='t' AND request %"
       const queries = _.times(20, () => pool.query(queryText, [queryTextMatch]))

--- a/packages/v-pool/test/sizing.js
+++ b/packages/v-pool/test/sizing.js
@@ -64,7 +64,7 @@ describe('pool size of 1', () => {
       var queryRequestsRowCount = result.rows[0].COUNT
 
       if(queryRequestsRowCount > 4000){
-        console.log(" -- Skipping test because query_requests table is too large")
+        console.log(" -- Skipping the following test because query_requests table is too large:")
         return yield pool.end()
       }
 


### PR DESCRIPTION
This test was potentially timing out after the query_requests table grew above 5000 requests. This will pass in CI always since it is a fresh database, but running against in-use databases, the test would likely fail. Now, we skip the test in this case, as we don't know any way to query this information in a way that would scale to any size in a reasonable timeout.