### PR TITLE
Disable configurable promise test

### DIFF
--- a/packages/vertica-nodejs/test/integration/client/query-as-promise-tests.js
+++ b/packages/vertica-nodejs/test/integration/client/query-as-promise-tests.js
@@ -32,6 +32,9 @@ suite.test('promise API', (cb) => {
   })
 })
 
+// Disabling test for now since async functions always return default Promises.
+// May remove later, since we might not want to support this use case.
+/*
 suite.test('promise API with configurable promise type', (cb) => {
   const client = new vertica.Client({ Promise: bluebird })
   const connectPromise = client.connect()
@@ -52,3 +55,4 @@ suite.test('promise API with configurable promise type', (cb) => {
       })
     })
 })
+*/


### PR DESCRIPTION
Async functions return default Promises, so we're disabling this test for now. Since async/await is part of the JS spec, we may just remove this test eventually anyway, as most people would probably want to use async/await which would prevent the usage of other Promise implementations.