### PR TITLE
Readme redirect and licensing

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,4 +88,4 @@ The causes and solutions to common errors can be found among the [Frequently Ask
 
 ## License
 
-Apache 2.0 License, please see [LICENSE](LICENSE) for details.
+Apache 2.0 License, please see [LICENSE](https://github.com/vertica/vertica-nodejs/blob/master/LICENSE) for details.

--- a/packages/v-connection-string/README.md
+++ b/packages/v-connection-string/README.md
@@ -1,100 +1,22 @@
 # v-connection-string
 
-<!-- refer back to original node-postgres for samples once compatibility with Vertica is ensured -->
+[![License](https://img.shields.io/badge/License-Apache%202.0-orange.svg)](https://opensource.org/licenses/Apache-2.0)
+[![NPM version](https://img.shields.io/npm/v/v-connection-string?color=blue)](https://www.npmjs.com/package/v-connection-string)
+[![NPM downloads](https://img.shields.io/npm/dm/v-connection-string)](https://www.npmjs.com/package/v-connection-string)
 
-<!-- NPM package when published -->
-<!-- NPM downloads when published -->
-[![License](https://img.shields.io/github/license/vertica/vertica-nodejs)](https://opensource.org/licenses/MIT)
+Enables using connection strings to establish connections with the vertica-nodejs driver
 
-Non-blocking Vertica client for Node.js. Pure JavaScript and optional native libpq bindings.
-
-## DISCLAIMER: 
-vertica-nodejs is still pre-release and actively being improved. As of 5/5/22 this is not intended for use in production environments. 
-
-<!--
 ## Documentation
 
-Each package in this repo should have its own readme more focused on how to develop/contribute. For more information on how to contribute, check out our [contributing guidelines](#contributing-guidelines).-->
+v-connection-string is part of a much larger project, vertica-nodejs. While each individual package should have its own documentation for exposing and detailing related components of the vertica-nodejs API, the main location for those using the driver can be found here:
 
-<!-- ## Installation
-    To install vertica-nodejs with npm: ``` TO DO ```
+- [vertica-nodejs](https://github.com/vertica/vertica-nodejs/tree/master/packages/vertica-nodejs)
 
-    To use vertica-nodejs linked locally from source (not recommended in production): ``` TO DO - Take notes from http://confluence.verticacorp.com/display/DEV/Node.js+Development+Resources```
+Other packages part of the vertica-nodejs project can be found here:
 
--->
-## Usage
-
-var parse = require('pg-connection-string').parse;
-var config = parse('vertica://someuser:somepassword@somehost:381/somedatabase')
-
-The resulting config contains a subset of the following properties:
-* `host` - Vertica server hostname 
-* `port` - port on which to connect
-* `user` - User with which to authenticate to the server
-* `password` - Corresponding password
-* `database` - Database name within the server
-### Features
-
-- Pure JavaScript client and native libpq bindings share _the same API_
-- Connection pooling
-- Extensible JS ↔ Vertica data-type coercion
-<!-- - Supported Vertica features -->
-  <!-- - Async notifications with `LISTEN/NOTIFY` verifiy this -->
-  <!-- - Bulk import & export with `COPY TO/COPY FROM` not part of the MVP -->
-
-## Support
-
-vertica-nodejs is free software. If you encounter a bug with the library please open an issue on the [GitHub repo](https://github.com/vertica/vertica-nodejs). If you have questions unanswered by the documentation please open an issue pointing out how the documentation was unclear and we will address it as needed. 
-
-When you open an issue please provide:
-
-- version of Node
-- version of Vertica
-- smallest possible snippet of code to reproduce the problem
-
-<!-- 
-## Contributing
-
-Outside contributions to this project are greatly appreciated. Following standard Vertica open source practices, please see [CONTRIBUTING.md](CONTRIBUTING.md)
--->
-
-## Examples
-
-See the [examples directory](https://github.com/vertica/vertica-nodejs/tree/master/examples) for sample applications showing how to use the vertica-nodejs client driver.
-
-## Setting up for local development
-
-1. Clone the repo
-2. From your workspace root run `yarn` and then `yarn lerna bootstrap`
-3. Ensure you have a Vertica instance running with 
-4. Ensure you have the proper environment variables configured for connecting to the instance (`V_HOST`, `V_PORT`, `V_USER`, `V_PASSWORD`, `V_DATABASE`, `V_BACKUP_SERVER_NODE`)
-5. Run `yarn test` to run all the tests, or run `yarn test` from within an individual package to only run that package's tests
-
-If using VS Code, you can install the `Remote - Containers` extension and it will use the configuration under the `.devcontainer` folder to automatically create dev containers, including Vertica.  See [here](https://code.visualstudio.com/docs/remote/containers) for more information on developing in containers using VS Code.  This process will complete steps 2 to 4 above.
-
-## Troubleshooting and FAQ
-
-The causes and solutions to common errors can be found among the [Frequently Asked Questions (FAQ)](https://github.com/vertica/vertica-nodejs/wiki/FAQ)
+- [v-pool](https://github.com/vertica/vertica-nodejs/tree/master/packages/v-pool)
+- [v-protocol](https://github.com/vertica/vertica-nodejs/tree/master/packages/v-protocol)
 
 ## License
 
-<!-- Original work Copyright (c) 2010-2020 Brian Carlson (brian.m.carlson@gmail.com) -->
-<!-- Modified work Copyright (c) 2022 Micro Focus or one of its affiliates.  -->
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
+Apache 2.0 License, please see [LICENSE](https://github.com/vertica/vertica-nodejs/blob/master/LICENSE) for details.

--- a/packages/v-pool/README.md
+++ b/packages/v-pool/README.md
@@ -1,90 +1,22 @@
 # v-pool
 
-<!-- refer back to original node-postgres for samples once compatibility with Vertica is ensured -->
+[![License](https://img.shields.io/badge/License-Apache%202.0-orange.svg)](https://opensource.org/licenses/Apache-2.0)
+[![NPM version](https://img.shields.io/npm/v/v-pool?color=blue)](https://www.npmjs.com/package/v-pool)
+[![NPM downloads](https://img.shields.io/npm/dm/v-pool)](https://www.npmjs.com/package/v-pool)
 
-<!-- NPM package when published -->
-<!-- NPM downloads when published -->
-[![License](https://img.shields.io/github/license/vertica/vertica-nodejs)](https://opensource.org/licenses/MIT)
+Enables connection pooling with the vertica-nodejs driver
 
-Non-blocking Vertica client for Node.js. Pure JavaScript and optional native libpq bindings.
-
-## DISCLAIMER: 
-vertica-nodejs is still pre-release and actively being improved. As of 5/5/22 this is not intended for use in production environments. 
-
-<!--
 ## Documentation
 
-Each package in this repo should have its own readme more focused on how to develop/contribute. For more information on how to contribute, check out our [contributing guidelines](#contributing-guidelines).-->
+v-pool is part of a much larger project, vertica-nodejs. While each individual package should have its own documentation for exposing and detailing related components of the vertica-nodejs API, the main location for those using the driver can be found here:
 
-<!-- ## Installation
-    To install vertica-nodejs with npm: ``` TO DO ```
+- [vertica-nodejs](https://github.com/vertica/vertica-nodejs/tree/master/packages/vertica-nodejs)
 
-    To use vertica-nodejs linked locally from source (not recommended in production): ``` TO DO - Take notes from http://confluence.verticacorp.com/display/DEV/Node.js+Development+Resources```
+Other packages part of the vertica-nodejs project can be found here:
 
--->
-
-### Features
-
-- Pure JavaScript client and native libpq bindings share _the same API_
-- Connection pooling
-- Extensible JS ↔ Vertica data-type coercion
-<!-- - Supported Vertica features -->
-  <!-- - Async notifications with `LISTEN/NOTIFY` verifiy this -->
-  <!-- - Bulk import & export with `COPY TO/COPY FROM` not part of the MVP -->
-
-## Support
-
-vertica-nodejs is free software. If you encounter a bug with the library please open an issue on the [GitHub repo](https://github.com/vertica/vertica-nodejs). If you have questions unanswered by the documentation please open an issue pointing out how the documentation was unclear and we will address it as needed. 
-
-When you open an issue please provide:
-
-- version of Node
-- version of Vertica
-- smallest possible snippet of code to reproduce the problem
-
-<!-- 
-## Contributing
-
-Outside contributions to this project are greatly appreciated. Following standard Vertica open source practices, please see [CONTRIBUTING.md](CONTRIBUTING.md)
--->
-
-## Examples
-
-See the [examples directory](https://github.com/vertica/vertica-nodejs/tree/master/examples) for sample applications showing how to use the vertica-nodejs client driver.
-
-## Setting up for local development
-
-1. Clone the repo
-2. From your workspace root run `yarn` and then `yarn lerna bootstrap`
-3. Ensure you have a Vertica instance running with 
-4. Ensure you have the proper environment variables configured for connecting to the instance (`V_HOST`, `V_PORT`, `V_USER`, `V_PASSWORD`, `V_DATABASE`, `V_BACKUP_SERVER_NODE`)
-5. Run `yarn test` to run all the tests, or run `yarn test` from within an individual package to only run that package's tests
-
-If using VS Code, you can install the `Remote - Containers` extension and it will use the configuration under the `.devcontainer` folder to automatically create dev containers, including Vertica.  See [here](https://code.visualstudio.com/docs/remote/containers) for more information on developing in containers using VS Code.  This process will complete steps 2 to 4 above.
-
-## Troubleshooting and FAQ
-
-The causes and solutions to common errors can be found among the [Frequently Asked Questions (FAQ)](https://github.com/vertica/vertica-nodejs/wiki/FAQ)
+- [v-connection-string](https://github.com/vertica/vertica-nodejs/tree/master/packages/v-connection-string)
+- [v-protocol](https://github.com/vertica/vertica-nodejs/tree/master/packages/v-protocol)
 
 ## License
 
-<!-- Original work Copyright (c) 2010-2020 Brian Carlson (brian.m.carlson@gmail.com) -->
-<!-- Modified work Copyright (c) 2022 Micro Focus or one of its affiliates.  -->
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
+Apache 2.0 License, please see [LICENSE](https://github.com/vertica/vertica-nodejs/blob/master/LICENSE) for details.

--- a/packages/v-protocol/README.md
+++ b/packages/v-protocol/README.md
@@ -1,14 +1,23 @@
 # v-protocol
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-orange.svg)](https://opensource.org/licenses/Apache-2.0)
+[![NPM version](https://img.shields.io/npm/v/v-protocol?color=blue)](https://www.npmjs.com/package/v-protocol)
+[![NPM downloads](https://img.shields.io/npm/dm/v-protocol)](https://www.npmjs.com/package/v-protocol)
 
-Vertica protocol code used to send and receive messages defined in the Vertica protocol.
+Enables use of standard Vertica client-server protocol in the vertica-nodejs driver.
 This is used by the [vertica-nodejs](https://github.com/vertica/vertica-nodejs) client driver and is *not* meant to be
-used by developers writing their own applications with vertica-nodejs.
+used separately by developers writing their own applications with vertica-nodejs.
 
 ## Documentation
 
-Please see [vertica-nodejs](https://github.com/vertica/vertica-nodejs), since this is only a dependency of that package. 
+v-protocol is part of a much larger project, vertica-nodejs. While each individual package should have its own documentation for exposing and detailing related components of the vertica-nodejs API, the main location for those using the driver can be found here:
+
+- [vertica-nodejs](https://github.com/vertica/vertica-nodejs/tree/master/packages/vertica-nodejs)
+
+Other packages part of the vertica-nodejs project can be found here:
+
+- [v-connection-string](https://github.com/vertica/vertica-nodejs/tree/master/packages/v-connection-string)
+- [v-pool](https://github.com/vertica/vertica-nodejs/tree/master/packages/v-pool)
 
 ## License
 

--- a/packages/vertica-nodejs/README.md
+++ b/packages/vertica-nodejs/README.md
@@ -343,5 +343,5 @@ Currently the client only supports type parsing for booleans, integers, and floa
 
 ## License
 
-Apache 2.0 License, please see [LICENSE](LICENSE) for details.
+Apache 2.0 License, please see [LICENSE](https://github.com/vertica/vertica-nodejs/blob/master/LICENSE) for details.
 


### PR DESCRIPTION
Updates to readmes for dependency packages to display licensing and point to the vertica-nodejs readme