### PR TITLE
Support of Node engine v12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,9 @@ jobs:
         #node: ['8', '10', '12', '14', '16', '17']
         #os: [ubuntu-latest, windows-latest, macos-latest]
         # let's make it a little bit simple for now
-        # current target version will be 14.
+        # current minimal version will be 12.
         # TODO: investigate the multipe version matrix with single Vertica instance
-        node: ['14']
+        node: ['12', '14']
         os: [ubuntu-latest]
     name: Node.js ${{ matrix.node }} (${{ matrix.os }})
     steps:

--- a/packages/vertica-nodejs/package.json
+++ b/packages/vertica-nodejs/package.json
@@ -49,6 +49,6 @@
   ],
   "license": "Apache-2.0",
   "engines": {
-    "node": ">= 14.0.0"
+    "node": ">= 12.0.0"
   }
 }


### PR DESCRIPTION
# Rationale for this change

Currently minimal version of Node engine is 14, but some projects may require support of earlier engine versions. Suggestion is to decrease minimal required version of engine to 12.

# What changes are included in this PR?

vertica-nodejs package now requires node version >= 12, this version also added to CI matrix