### PR TITLE
Fix relevant IntelliJ Ultimate and ESLint linting warnings in examples

### DIFF
--- a/examples/basic.js
+++ b/examples/basic.js
@@ -32,7 +32,7 @@ async function tearDown() {
   client.end()
 }
 
-async function main() {
+async function getAllEmployees() {
   await setup()
 
   // Run SELECT query
@@ -42,6 +42,8 @@ async function main() {
   console.log(res)
 
   await tearDown()
+
+  return res
 }
 
-main()
+getAllEmployees().then(console.log).catch(console.log)

--- a/examples/parameterized-query.js
+++ b/examples/parameterized-query.js
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 const { Client } = require('vertica-nodejs')
 
 const client = new Client()
@@ -32,16 +31,15 @@ async function tearDown() {
   client.end()
 }
 
-async function main() {
+async function getEmployeesOlderThan50() {
   await setup()
 
   // Run parameterized query
-  var res = await client.query('SELECT * FROM Employee WHERE age > ?', [50])
-
-  // print results
-  console.log(res)
+  const res = await client.query('SELECT * FROM Employee WHERE age > ?', [50])
 
   await tearDown()
+
+  return res
 }
 
-main()
+getEmployeesOlderThan50().then(console.log).catch(console.log)

--- a/examples/prepared-statement.js
+++ b/examples/prepared-statement.js
@@ -38,16 +38,15 @@ async function tearDown() {
   client.end()
 }
 
-async function main() {
+async function getEmployeesOlderThan50() {
   await setup()
 
   // Run prepared statement
-  var res = await client.query(fetchOlderQuery)
-
-  // print results
-  console.log(res)
+  const res = await client.query(fetchOlderQuery)
 
   await tearDown()
+
+  return res
 }
 
-main()
+getEmployeesOlderThan50().then(console.log).catch(console.log)

--- a/examples/update.js
+++ b/examples/update.js
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 const { Client } = require('vertica-nodejs')
-const Result = require('vertica-nodejs/lib/result')
 
 const client = new Client()
 

--- a/examples/update.js
+++ b/examples/update.js
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 const { Client } = require('vertica-nodejs')
+const Result = require('vertica-nodejs/lib/result')
 
 const client = new Client()
 
@@ -32,24 +33,22 @@ async function tearDown() {
   client.end()
 }
 
-async function main() {
+async function getAllEmployees() {
   await setup()
 
   // Run UPDATE query
-  var res = await client.query('UPDATE Employee SET age = age + 1')
+  const res = await client.query('UPDATE Employee SET age = age + 1')
 
   // print results
-  console.log("UPDATE complete")
+  console.log('UPDATE complete')
   console.log(res)
 
   // Run SELECT query
-  var allRows = await client.query('SELECT * FROM Employee')
-
-  // print results
-  console.log("SELECT complete")
-  console.log(allRows.rows)
+  const allRows = await client.query('SELECT * FROM Employee')
 
   await tearDown()
+
+  return allRows.rows
 }
 
-main()
+getAllEmployees().then(console.log).catch(console.log)


### PR DESCRIPTION
This change addresses the following issues found by IntelliJ Ultimate and ESLint:
1. inconsistent quotes
2. unhandled Promises returned from main()
3. unnecessary usages of var
