### PR TITLE
Clean up client and connection parameters

### DIFF
--- a/packages/v-pool/test/index.js
+++ b/packages/v-pool/test/index.js
@@ -41,7 +41,7 @@ describe('pool', function () {
       pool.connect(function (err, client, release) {
         release()
         if (err) return done(err)
-        expect(client.binary).to.eql(true)
+        expect(client.connectionParameters.binary).to.eql(true)
         pool.end(done)
       })
     })

--- a/packages/vertica-nodejs/lib/client.js
+++ b/packages/vertica-nodejs/lib/client.js
@@ -70,11 +70,14 @@ class Client extends EventEmitter {
         client_label: this.connectionParameters.client_label,
       })
     this.queryQueue = []
-    this.binary = c.binary || defaults.binary
     this.processID = null
     this.secretKey = null
     this.tls_mode = this.connectionParameters.tls_mode || 'disable'
     this.tls_trusted_certs = this.connectionParameters.tls_trusted_certs
+
+    delete this.connectionParameters.tls_mode
+    delete this.connectionParameters.tls_trusted_certs
+
     this._connectionTimeoutMillis = c.connectionTimeoutMillis || 0
   }
 
@@ -649,7 +652,8 @@ class Client extends EventEmitter {
       }
     }
 
-    if (this.binary && !query.binary) {
+    const binary = this.connectionParameters.binary || defaults.binary
+    if (binary && !query.binary) {
       query.binary = true
     }
 

--- a/packages/vertica-nodejs/lib/client.js
+++ b/packages/vertica-nodejs/lib/client.js
@@ -26,8 +26,6 @@ var Query = require('./query')
 var defaults = require('./defaults')
 var Connection = require('./connection')
 
-// and all tls related properties including the commented out ones should get moved from client to connection-parameters
-
 class Client extends EventEmitter {
   constructor(config) {
     super()

--- a/packages/vertica-nodejs/lib/client.js
+++ b/packages/vertica-nodejs/lib/client.js
@@ -46,8 +46,6 @@ class Client extends EventEmitter {
       value: this.connectionParameters.password,
     })
 
-    this.replication = this.connectionParameters.replication
-
     this.client_label = this.connectionParameters.client_label;
     this.protocol_version = this.connectionParameters.protocol_version;
 
@@ -67,8 +65,6 @@ class Client extends EventEmitter {
         stream: c.stream,
         tls_mode: this.connectionParameters.tls_mode,
         tls_trusted_certs: this.connectionParameters.tls_trusted_certs,
-        //tls_client_key: this.connectionParameters.tls_client_key,
-        //tls_client_cert: this.connectionParameters.tls_client_cert,
         keepAlive: c.keepAlive || false,
         keepAliveInitialDelayMillis: c.keepAliveInitialDelayMillis || 0,
         encoding: this.connectionParameters.client_encoding || 'utf8',
@@ -79,8 +75,6 @@ class Client extends EventEmitter {
     this.processID = null
     this.secretKey = null
     this.tls_mode = this.connectionParameters.tls_mode || 'disable'
-    //this.tls_client_key = this.connectionParameters.tls_client_key
-    //this.tls_client_cert = this.connectionParameters.tls_client_cert
     this.tls_trusted_certs = this.connectionParameters.tls_trusted_certs
     this._connectionTimeoutMillis = c.connectionTimeoutMillis || 0
   }

--- a/packages/vertica-nodejs/lib/client.js
+++ b/packages/vertica-nodejs/lib/client.js
@@ -46,7 +46,6 @@ class Client extends EventEmitter {
       value: this.connectionParameters.password,
     })
 
-    this.client_label = this.connectionParameters.client_label;
     this.protocol_version = this.connectionParameters.protocol_version;
 
     var c = config || {}

--- a/packages/vertica-nodejs/lib/client.js
+++ b/packages/vertica-nodejs/lib/client.js
@@ -652,11 +652,7 @@ class Client extends EventEmitter {
       }
     }
 
-<<<<<<< HEAD
-    const binary = c.binary || defaults.binary
-=======
     const binary = this.connectionParameters.binary || defaults.binary
->>>>>>> cleanup_params_testing_incr
     if (binary && !query.binary) {
       query.binary = true
     }

--- a/packages/vertica-nodejs/lib/client.js
+++ b/packages/vertica-nodejs/lib/client.js
@@ -26,6 +26,8 @@ var Query = require('./query')
 var defaults = require('./defaults')
 var Connection = require('./connection')
 
+// and all tls related properties including the commented out ones should get moved from client to connection-parameters
+
 class Client extends EventEmitter {
   constructor(config) {
     super()
@@ -46,11 +48,6 @@ class Client extends EventEmitter {
       value: this.connectionParameters.password,
     })
 
-    this.replication = this.connectionParameters.replication
-
-    this.client_label = this.connectionParameters.client_label;
-    this.protocol_version = this.connectionParameters.protocol_version;
-
     var c = config || {}
 
     this._Promise = c.Promise || global.Promise
@@ -67,20 +64,15 @@ class Client extends EventEmitter {
         stream: c.stream,
         tls_mode: this.connectionParameters.tls_mode,
         tls_trusted_certs: this.connectionParameters.tls_trusted_certs,
-        //tls_client_key: this.connectionParameters.tls_client_key,
-        //tls_client_cert: this.connectionParameters.tls_client_cert,
         keepAlive: c.keepAlive || false,
         keepAliveInitialDelayMillis: c.keepAliveInitialDelayMillis || 0,
         encoding: this.connectionParameters.client_encoding || 'utf8',
         client_label: this.connectionParameters.client_label,
       })
     this.queryQueue = []
-    this.binary = c.binary || defaults.binary
     this.processID = null
     this.secretKey = null
     this.tls_mode = this.connectionParameters.tls_mode || 'disable'
-    //this.tls_client_key = this.connectionParameters.tls_client_key
-    //this.tls_client_cert = this.connectionParameters.tls_client_cert
     this.tls_trusted_certs = this.connectionParameters.tls_trusted_certs
     this._connectionTimeoutMillis = c.connectionTimeoutMillis || 0
   }
@@ -317,7 +309,7 @@ class Client extends EventEmitter {
 
   _handleParameterStatus(msg) {
     const min_supported_version = (3 << 16 | 5)         // 3.5
-    const max_supported_version = this.protocol_version // for now we are enforcing 3.5
+    const max_supported_version = this.connectionParameters.protocol_version // for now we are enforcing 3.5
     switch(msg.parameterName) {
       // right now we only care about the protocol_version
       // if we want to have the parameterStatus message update any other connection properties, add them here
@@ -656,7 +648,8 @@ class Client extends EventEmitter {
       }
     }
 
-    if (this.binary && !query.binary) {
+    const binary = c.binary || defaults.binary
+    if (binary && !query.binary) {
       query.binary = true
     }
 

--- a/packages/vertica-nodejs/mochatest/integration/client/vertica-connection-params-tests.js
+++ b/packages/vertica-nodejs/mochatest/integration/client/vertica-connection-params-tests.js
@@ -23,7 +23,7 @@ describe('vertica label connection parameter', function () {
 
     //assert creating a client connection will use default label
     var client_default = new vertica.Client()
-    assert.equal(client_default.client_label, vertica.defaults.client_label)
+    assert.equal(client_default.connectionParameters.client_label, vertica.defaults.client_label)
     client_default.connect()
     client_default.query('SELECT GET_CLIENT_LABEL()', (err, res) => {
       if (err){
@@ -39,7 +39,7 @@ describe('vertica label connection parameter', function () {
   it('can be specified and used in a client connection', function(done) {
     // assert creating a client connection with specified label will persist
     var client_test = new vertica.Client({client_label: 'distinctLabel'})
-    assert.equal(client_test.client_label, 'distinctLabel')
+    assert.equal(client_test.connectionParameters.client_label, 'distinctLabel')
     client_test.connect()
     client_test.query('SELECT GET_CLIENT_LABEL()', (err, res) => {
       if (err){


### PR DESCRIPTION
This PR removes some parameters that did not need to be fields of Client since they are already part of connection parameters.