### PR TITLE
Tls new configuration options

### DIFF
--- a/packages/v-connection-string/package.json
+++ b/packages/v-connection-string/package.json
@@ -1,6 +1,6 @@
 {
   "name": "v-connection-string",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Functions for dealing with a Vertica connection string",
   "main": "./index.js",
   "types": "./index.d.ts",

--- a/packages/v-pool/package.json
+++ b/packages/v-pool/package.json
@@ -1,6 +1,6 @@
 {
   "name": "v-pool",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Connection pool for Vertica",
   "main": "index.js",
   "directories": {
@@ -35,6 +35,6 @@
     "mocha": "^7.1.2"
   },
   "peerDependencies": {
-    "vertica-nodejs": "1.0.2"
+    "vertica-nodejs": "1.0.3"
   }
 }

--- a/packages/v-protocol/package.json
+++ b/packages/v-protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "v-protocol",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "The Vertica client/server binary protocol, implemented in TypeScript",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/vertica-nodejs/lib/client.js
+++ b/packages/vertica-nodejs/lib/client.js
@@ -62,6 +62,7 @@ class Client extends EventEmitter {
       c.connection ||
       new Connection({
         stream: c.stream,
+        tls_config: this.connectionParameters.tls_config,
         tls_mode: this.connectionParameters.tls_mode,
         tls_trusted_certs: this.connectionParameters.tls_trusted_certs,
         keepAlive: c.keepAlive || false,
@@ -72,6 +73,7 @@ class Client extends EventEmitter {
     this.queryQueue = []
     this.processID = null
     this.secretKey = null
+    this.tls_config = this.connectionParameters.tls_config
     this.tls_mode = this.connectionParameters.tls_mode || 'disable'
     this.tls_trusted_certs = this.connectionParameters.tls_trusted_certs
 
@@ -186,7 +188,7 @@ class Client extends EventEmitter {
     // once connection is established send startup message
     con.on('connect', function () {
       // SSLRequest Message
-      if (self.tls_mode !== 'disable') {
+      if (self.tls_mode !== 'disable' || self.tls_config !== undefined) {
         con.requestSsl()
       } else {
         con.startup(self.getStartupConf())

--- a/packages/vertica-nodejs/lib/client.js
+++ b/packages/vertica-nodejs/lib/client.js
@@ -189,12 +189,6 @@ class Client extends EventEmitter {
     // once connection is established send startup message
     con.on('connect', function () {
       // SSLRequest Message
-      if (self.tls_config === undefined) {
-        console.log("TLS config is undefined")
-      }
-      else {
-        console.log("TLS config is not undefined")
-      }
       if (self.tls_mode !== 'disable' || self.tls_config !== undefined) {
         con.requestSsl()
       } else {

--- a/packages/vertica-nodejs/lib/client.js
+++ b/packages/vertica-nodejs/lib/client.js
@@ -190,6 +190,7 @@ class Client extends EventEmitter {
     con.on('connect', function () {
       // SSLRequest Message
       if (self.tls_mode !== 'disable' || self.tls_config !== undefined) {
+        console.log("Requesting SSL")
         con.requestSsl()
       } else {
         con.startup(self.getStartupConf())

--- a/packages/vertica-nodejs/lib/client.js
+++ b/packages/vertica-nodejs/lib/client.js
@@ -190,7 +190,6 @@ class Client extends EventEmitter {
     con.on('connect', function () {
       // SSLRequest Message
       if (self.tls_mode !== 'disable' || self.tls_config !== undefined) {
-        console.log("Requesting SSL")
         con.requestSsl()
       } else {
         con.startup(self.getStartupConf())

--- a/packages/vertica-nodejs/lib/client.js
+++ b/packages/vertica-nodejs/lib/client.js
@@ -77,6 +77,7 @@ class Client extends EventEmitter {
     this.tls_mode = this.connectionParameters.tls_mode || 'disable'
     this.tls_trusted_certs = this.connectionParameters.tls_trusted_certs
 
+    delete this.connectionParameters.tls_config
     delete this.connectionParameters.tls_mode
     delete this.connectionParameters.tls_trusted_certs
 
@@ -188,6 +189,12 @@ class Client extends EventEmitter {
     // once connection is established send startup message
     con.on('connect', function () {
       // SSLRequest Message
+      if (self.tls_config === undefined) {
+        console.log("TLS config is undefined")
+      }
+      else {
+        console.log("TLS config is not undefined")
+      }
       if (self.tls_mode !== 'disable' || self.tls_config !== undefined) {
         con.requestSsl()
       } else {

--- a/packages/vertica-nodejs/lib/connection-parameters.js
+++ b/packages/vertica-nodejs/lib/connection-parameters.js
@@ -97,12 +97,12 @@ class ConnectionParameters {
     // if the user wants to have more control over the tls socket they can provide their own tls_config object
     // this is particularly useful for customers migrating over from node-vertica
     // otherwise we will support standard tls mode support as in other drivers
-    if (this.tls_config === undefined) {
+    //if (this.tls_config === undefined) {
       this.tls_mode = val('tls_mode', config)
       //this.tls_client_key = val('tls_client_key', config)
       //this.tls_client_cert = val('tls_client_cert', config)
       this.tls_trusted_certs = val('tls_trusted_certs', config)
-    }
+    //}
     this.client_encoding = val('client_encoding', config)
     this.replication = val('replication', config)
     // a domain socket begins with '/'

--- a/packages/vertica-nodejs/lib/connection-parameters.js
+++ b/packages/vertica-nodejs/lib/connection-parameters.js
@@ -93,11 +93,16 @@ class ConnectionParameters {
     this.binary = val('binary', config)
     this.options = val('options', config)
 
-    this.tls_mode = val('tls_mode', config)
-    //this.tls_client_key = val('tls_client_key', config)
-    //this.tls_client_cert = val('tls_client_cert', config)
-    this.tls_trusted_certs = val('tls_trusted_certs', config)
-
+    this.tls_config = val('tls_config', config)
+    // if the user wants to have more control over the tls socket they can provide their own tls_config object
+    // this is particularly useful for customers migrating over from node-vertica
+    // otherwise we will support standard tls mode support as in other drivers
+    if (this.tls_config === undefined) {
+      this.tls_mode = val('tls_mode', config)
+      //this.tls_client_key = val('tls_client_key', config)
+      //this.tls_client_cert = val('tls_client_cert', config)
+      this.tls_trusted_certs = val('tls_trusted_certs', config)
+    }
     this.client_encoding = val('client_encoding', config)
     this.replication = val('replication', config)
     // a domain socket begins with '/'

--- a/packages/vertica-nodejs/lib/connection-parameters.js
+++ b/packages/vertica-nodejs/lib/connection-parameters.js
@@ -97,12 +97,10 @@ class ConnectionParameters {
     // if the user wants to have more control over the tls socket they can provide their own tls_config object
     // this is particularly useful for customers migrating over from node-vertica
     // otherwise we will support standard tls mode support as in other drivers
-    //if (this.tls_config === undefined) {
-      this.tls_mode = val('tls_mode', config)
-      //this.tls_client_key = val('tls_client_key', config)
-      //this.tls_client_cert = val('tls_client_cert', config)
-      this.tls_trusted_certs = val('tls_trusted_certs', config)
-    //}
+    this.tls_mode = val('tls_mode', config)
+    //this.tls_client_key = val('tls_client_key', config)
+    //this.tls_client_cert = val('tls_client_cert', config)
+    this.tls_trusted_certs = val('tls_trusted_certs', config)
     this.client_encoding = val('client_encoding', config)
     this.replication = val('replication', config)
     // a domain socket begins with '/'

--- a/packages/vertica-nodejs/lib/connection.js
+++ b/packages/vertica-nodejs/lib/connection.js
@@ -182,10 +182,10 @@ class Connection extends EventEmitter {
         else {
           self.emit('error', 'Invalid TLS mode has been entered'); // should be unreachable
         }
+        
       }
       self.attachListeners(self.stream)
       self.stream.on('error', reportStreamError)
-
       self.emit('sslconnect')
     })
   } 
@@ -208,6 +208,7 @@ class Connection extends EventEmitter {
   }
 
   startup(config) {
+    console.log(config)
     this.stream.write(serialize.startup(config))
   }
 

--- a/packages/vertica-nodejs/lib/connection.js
+++ b/packages/vertica-nodejs/lib/connection.js
@@ -44,14 +44,10 @@ class Connection extends EventEmitter {
     this.tls_config = config.tls_config
 
     if (this.tls_config === undefined) {
-      console.log("TLS config undefined")
       this.tls_mode = config.tls_mode || 'disable'
       //this.tls_client_key = config.tls_client_key
       //this.tls_client_cert = config.tls_client_cert
       this.tls_trusted_certs = config.tls_trusted_certs
-    }
-    else {
-      console.log("TLS config not undefined")
     }
     var self = this
     this.on('newListener', function (eventName) {

--- a/packages/vertica-nodejs/lib/connection.js
+++ b/packages/vertica-nodejs/lib/connection.js
@@ -41,11 +41,14 @@ class Connection extends EventEmitter {
     this.statementCounter[0] = 0
 
     // encryption
-    this.tls_mode = config.tls_mode || 'disable'
-    //this.tls_client_key = config.tls_client_key
-    //this.tls_client_cert = config.tls_client_cert
-    this.tls_trusted_certs = config.tls_trusted_certs
+    this.tls_config = config.tls_config
 
+    if (this.tls_config === undefined) {
+      this.tls_mode = config.tls_mode || 'disable'
+      //this.tls_client_key = config.tls_client_key
+      //this.tls_client_cert = config.tls_client_cert
+      this.tls_trusted_certs = config.tls_trusted_certs
+    }
     var self = this
     this.on('newListener', function (eventName) {
       if (eventName === 'message') {
@@ -81,7 +84,11 @@ class Connection extends EventEmitter {
       self.emit('end')
     })
 
-    if (this.tls_mode === 'disable') {
+
+
+    // only try to connect with tls if we are set up to
+    // server might reject us if we dont, but we don't know that yet
+    if (this.tls_mode === 'disable' || (this.tls_mode === undefined && this.tls_config === undefined)) {
       return this.attachListeners(this.stream)
     }
 
@@ -100,77 +107,88 @@ class Connection extends EventEmitter {
       }
       // tls_mode LOGIC
       var tls = require('tls')
-      var tls_options = {socket: self.stream}
-      // Instead of keeping track of whether mutual mode is on or not, just check to see if the properties 
-      // needed for mutual mode are defined. If they are and mutual mode is off, sending it won't cause a 
-      // problem because the server won't be asking for them.
-      // Also, terminology conflicts between vertica documentation and the node tls package may make this 
-      // seem confusing. checkServerIdentity is the function equivalent to the hostname verifier.
-      // With an undefined checkServerIdentity function, we are still checking to see that the server
-      // certificate is signed by the CA (default or provided).
 
-      if (self.tls_mode === 'require') { // basic TLS connection, does not verify CA certificate
-        tls_options.rejectUnauthorized = false
-        tls_options.checkServerIdentity = (host , cert) => undefined
-        if (self.tls_trusted_certs) {
-          tls_options.ca = fs.readFileSync(self.tls_trusted_certs).toString()
-        }
-        /*if (self.tls_client_cert) {// the client won't know whether or not this is required, depends on server mode
-          tls_options.cert = fs.readFileSync(self.tls_client_cert).toString()
-        }
-        if (self.tls_client_key) {
-          tls_options.key = fs.readFileSync(self.tls_client_key).toString()
-        }*/
-        try {
-          self.stream = tls.connect(tls_options);
-        } catch (err) {
-          return self.emit('error', err)
-        }
-      }
-      else if (self.tls_mode === 'verify-ca') { //verify that the server certificate is signed by a trusted CA
-        try {
-          tls_options.rejectUnauthorized = true
-          tls_options.checkServerIdentity = (host, cer) => undefined
-          if (self.tls_trusted_certs) {
-            tls_options.ca = fs.readFileSync(self.tls_trusted_certs).toString()
-          }
-          /*if (self.tls_client_cert) {// the client won't know whether or not this is required, depends on server mode
-            tls_options.cert = fs.readFileSync(self.tls_client_cert).toString()
-          }
-          if (self.tls_client_key) {
-            tls_options.key = fs.readFileSync(self.tls_client_key).toString()
-          }*/
-          self.stream = tls.connect(tls_options)
-        } catch (err) {
-          return self.emit('error', err)
-        }
-      }
-      else if (self.tls_mode === 'verify-full') { //verify that the name on the CA-signed server certificate matches it's hostname
-        try {
-          tls_options.rejectUnauthorized = true
-          if (self.tls_trusted_certs) {
-            tls_options.ca = fs.readFileSync(self.tls_trusted_certs).toString()
-          }
-          /*if (self.tls_client_cert) {// the client won't know whether or not this is required, depends on server mode
-            tls_options.cert = fs.readFileSync(self.tls_client_cert).toString()
-          }
-          if (self.tls_client_key) {
-            tls_options.key = fs.readFileSync(self.tls_client_key).toString()
-          }*/
-          self.stream = tls.connect(tls_options)
-        } catch (err){
-          return self.emit('error', err)
-        }
+      // use tls_config if it has been provided
+      var tls_options = {}
+      if (self.tls_config !== undefined) {
+        tls_options = self.tls_config
+        tls_options.socket = self.stream
+        self.stream = tls.connect(tls_options)
       }
       else {
-        self.emit('error', 'Invalid TLS mode has been entered'); // should be unreachable
+        tls_options.socket = self.stream
+
+        // Instead of keeping track of whether mutual mode is on or not, just check to see if the properties 
+        // needed for mutual mode are defined. If they are and mutual mode is off, sending it won't cause a 
+        // problem because the server won't be asking for them.
+        // Also, terminology conflicts between vertica documentation and the node tls package may make this 
+        // seem confusing. checkServerIdentity is the function equivalent to the hostname verifier.
+        // With an undefined checkServerIdentity function, we are still checking to see that the server
+        // certificate is signed by the CA (default or provided).
+        
+        if (self.tls_mode === 'require') { // basic TLS connection, does not verify CA certificate
+          tls_options.rejectUnauthorized = false
+          tls_options.checkServerIdentity = (host , cert) => undefined
+          if (self.tls_trusted_certs) {
+            tls_options.ca = fs.readFileSync(self.tls_trusted_certs).toString()
+          }
+          /*if (self.tls_client_cert) {// the client won't know whether or not this is required, depends on server mode
+            tls_options.cert = fs.readFileSync(self.tls_client_cert).toString()
+          }
+          if (self.tls_client_key) {
+            tls_options.key = fs.readFileSync(self.tls_client_key).toString()
+          }*/
+          try {
+            self.stream = tls.connect(tls_options);
+          } catch (err) {
+            return self.emit('error', err)
+          }
+        }
+        else if (self.tls_mode === 'verify-ca') { //verify that the server certificate is signed by a trusted CA
+          try {
+            tls_options.rejectUnauthorized = true
+            tls_options.checkServerIdentity = (host, cer) => undefined
+            if (self.tls_trusted_certs) {
+              tls_options.ca = fs.readFileSync(self.tls_trusted_certs).toString()
+            }
+            /*if (self.tls_client_cert) {// the client won't know whether or not this is required, depends on server mode
+              tls_options.cert = fs.readFileSync(self.tls_client_cert).toString()
+            }
+            if (self.tls_client_key) {
+              tls_options.key = fs.readFileSync(self.tls_client_key).toString()
+            }*/
+            self.stream = tls.connect(tls_options)
+          } catch (err) {
+            return self.emit('error', err)
+          }
+        }
+        else if (self.tls_mode === 'verify-full') { //verify that the name on the CA-signed server certificate matches it's hostname
+          try {
+            tls_options.rejectUnauthorized = true
+            if (self.tls_trusted_certs) {
+              tls_options.ca = fs.readFileSync(self.tls_trusted_certs).toString()
+            }
+            /*if (self.tls_client_cert) {// the client won't know whether or not this is required, depends on server mode
+              tls_options.cert = fs.readFileSync(self.tls_client_cert).toString()
+            }
+            if (self.tls_client_key) {
+              tls_options.key = fs.readFileSync(self.tls_client_key).toString()
+            }*/
+            self.stream = tls.connect(tls_options)
+          } catch (err){
+            return self.emit('error', err)
+          }
+        }
+        else {
+          self.emit('error', 'Invalid TLS mode has been entered'); // should be unreachable
+        }
       }
       self.attachListeners(self.stream)
       self.stream.on('error', reportStreamError)
 
       self.emit('sslconnect')
     })
-  }
+  } 
 
   attachListeners(stream) {
     stream.on('end', () => {

--- a/packages/vertica-nodejs/lib/connection.js
+++ b/packages/vertica-nodejs/lib/connection.js
@@ -212,7 +212,6 @@ class Connection extends EventEmitter {
   }
 
   startup(config) {
-    console.log(config)
     this.stream.write(serialize.startup(config))
   }
 

--- a/packages/vertica-nodejs/lib/connection.js
+++ b/packages/vertica-nodejs/lib/connection.js
@@ -44,10 +44,14 @@ class Connection extends EventEmitter {
     this.tls_config = config.tls_config
 
     if (this.tls_config === undefined) {
+      console.log("TLS config undefined")
       this.tls_mode = config.tls_mode || 'disable'
       //this.tls_client_key = config.tls_client_key
       //this.tls_client_cert = config.tls_client_cert
       this.tls_trusted_certs = config.tls_trusted_certs
+    }
+    else {
+      console.log("TLS config not undefined")
     }
     var self = this
     this.on('newListener', function (eventName) {
@@ -88,7 +92,11 @@ class Connection extends EventEmitter {
 
     // only try to connect with tls if we are set up to
     // server might reject us if we dont, but we don't know that yet
-    if (this.tls_mode === 'disable' || (this.tls_mode === undefined && this.tls_config === undefined)) {
+    //if (this.tls_mode === 'disable' || (this.tls_mode === undefined && this.tls_config === undefined)) {
+      //return this.attachListeners(this.stream)
+    //}
+
+    if (self.tls_config === undefined && self.tls_mode === 'disable') {
       return this.attachListeners(this.stream)
     }
 

--- a/packages/vertica-nodejs/lib/connection.js
+++ b/packages/vertica-nodejs/lib/connection.js
@@ -86,12 +86,7 @@ class Connection extends EventEmitter {
 
 
 
-    // only try to connect with tls if we are set up to
-    // server might reject us if we dont, but we don't know that yet
-    //if (this.tls_mode === 'disable' || (this.tls_mode === undefined && this.tls_config === undefined)) {
-      //return this.attachListeners(this.stream)
-    //}
-
+    // only try to connect with tls if we are set up to handle it
     if (self.tls_config === undefined && self.tls_mode === 'disable') {
       return this.attachListeners(this.stream)
     }

--- a/packages/vertica-nodejs/package.json
+++ b/packages/vertica-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vertica-nodejs",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Vertica client - pure javascript & libpq with the same API",
   "keywords": [
     "database",
@@ -30,9 +30,9 @@
     "packet-reader": "1.0.0",
     "pg-types": "^2.1.0",
     "pgpass": "1.x",
-    "v-connection-string": "1.0.2",
-    "v-pool": "1.0.2",
-    "v-protocol": "1.0.2"
+    "v-connection-string": "1.0.3",
+    "v-pool": "1.0.3",
+    "v-protocol": "1.0.3"
   },
   "devDependencies": {
     "async": "0.9.0",

--- a/packages/vertica-nodejs/test/integration/connection/tls-tests.js
+++ b/packages/vertica-nodejs/test/integration/connection/tls-tests.js
@@ -178,7 +178,7 @@ suite.test('vertica tls - verify-full - valid server certificate', function () {
 // Test case for tls_config feature
 suite.test('vertica tls - tls_config feature', function() {
   var client = new vertica.Client({tls_config: {rejectUnauthorized: false,
-                                                checkServerIdentity = (host , cert) => undefined}
+                                                checkServerIdentity: (host , cert) => undefined}
                                   })
   client.connect(err => {
     if (err) {


### PR DESCRIPTION
The puropse of this PR is to add a new tls_config parameter that the user can provide themselves. This gives the user more control over the tls socket that is created. They still have the original option to provide the tls mode that they desire and the trusted ca certificates (if required), but this new tls_config parameter will make the transition easier for some from node-vertica to vertica-nodejs. This is also a alternate way to enable mTLS while that is still in development in the driver. 