### PR TITLE
Fix type parser overrides for connection pools

### DIFF
--- a/packages/vertica-nodejs/lib/type-overrides.js
+++ b/packages/vertica-nodejs/lib/type-overrides.js
@@ -26,7 +26,6 @@ types.setTypeParser(VerticaType.Numeric, types.getTypeParser(9, 'text'))
 types.setTypeParser(VerticaType.Varbinary, types.getTypeParser(9, 'text'))
 //types.setTypeParser(VerticaType.Uuid, types.getTypeParser(9, 'text')) //Uuid not introduced yet in the current protocol 3.5
 function TypeOverrides(userTypes) {
-  //console.log("Type Overrides called")
   this._types = userTypes || types
   this.text = {}
   this.binary = {}

--- a/packages/vertica-nodejs/lib/type-overrides.js
+++ b/packages/vertica-nodejs/lib/type-overrides.js
@@ -17,23 +17,19 @@
 const { VerticaType } = require('v-protocol')
 var types = require('pg-types')
 
+// this is a 'temporary' solution allowing us to continue to use pg-types as long as we can to avoid another large 
+// package implementation while we get close to the 1.0 release
+types.setTypeParser(VerticaType.Boolean, types.getTypeParser(16, 'text'))
+types.setTypeParser(VerticaType.Integer, types.getTypeParser(21, 'text'))
+types.setTypeParser(VerticaType.Float, types.getTypeParser(700, 'text'))
+types.setTypeParser(VerticaType.Numeric, types.getTypeParser(9, 'text'))
+types.setTypeParser(VerticaType.Varbinary, types.getTypeParser(9, 'text'))
+//types.setTypeParser(VerticaType.Uuid, types.getTypeParser(9, 'text')) //Uuid not introduced yet in the current protocol 3.5
 function TypeOverrides(userTypes) {
+  //console.log("Type Overrides called")
   this._types = userTypes || types
   this.text = {}
   this.binary = {}
-  // this is a 'temporary' solution allowing us to continue to use pg-types as long as we can to avoid another large 
-  // package implementation while we get close to the 1.0 release
-  if (this._types === types) {
-    // Types representing javascript primitives and their array. Keep parsing these, but use the correct typeID
-    this._types.setTypeParser(VerticaType.Boolean, 'text', this._types.getTypeParser(16, 'text'))  // boolean
-    this._types.setTypeParser(VerticaType.Integer, 'text', this._types.getTypeParser(21, 'text'))  // integer
-    this._types.setTypeParser(VerticaType.Float, 'text', this._types.getTypeParser(700, 'text')) // float
-
-    // Types that currently are being parsed as the wrong type, force these to be parsed as strings
-    this._types.setTypeParser(VerticaType.Numeric, 'text', this._types.getTypeParser(9, 'text'))  //numerics use varchar (no parser)
-    this._types.setTypeParser(VerticaType.Varbinary, 'text', this._types.getTypeParser(9, 'text'))  //varbinary use varchar(no parser)
-    this._types.setTypeParser(VerticaType.Uuid, 'text', this._types.getTypeParser(9, 'text'))  //uuid use varchar(no parser)
-  }
 }
 
 TypeOverrides.prototype.getOverrides = function (format) {

--- a/packages/vertica-nodejs/test/integration/client/prepared-statement-tests.js
+++ b/packages/vertica-nodejs/test/integration/client/prepared-statement-tests.js
@@ -109,7 +109,7 @@ var suite = new helper.Suite()
       if (err) {
         assert(false)
       }
-      assert.equal(JSON.stringify(res.rows.flat()), JSON.stringify(['t', 5, 'z', 'foo', '12345.67890']))
+      assert.equal(JSON.stringify(res.rows.flat()), JSON.stringify([true, 5, 'z', 'foo', '12345.67890']))
       done()
     })
   })


### PR DESCRIPTION
Previously the overriding type parsers between pg and Vertica was done in the TypeOverrides function within type-overrides.js. This caused issues when multiple clients were in use. The pg enum value for Boolean is the same as the Vertica Numeric. When we overrode the type parser for Vertica Boolean with pg Boolean once, it worked fine. But then we overrode Vertica Numeric with pg no parser, or string. Because of this, every subsequent client, when trying to override Vertica Boolean with pg Boolean would actually be overriding Vertica Boolean with the no parser. 

Now we prevent the issue by only overriding type parsers a single time outside of the TypeOverrides function