### PR TITLE
Added workload and client_os_hostname connection parameters

### DIFF
--- a/packages/vertica-nodejs/lib/client.js
+++ b/packages/vertica-nodejs/lib/client.js
@@ -15,6 +15,7 @@
 'use strict'
 
 var dns = require('dns')
+var os = require('os')
 var EventEmitter = require('events').EventEmitter
 var util = require('util')
 var utils = require('./utils')
@@ -76,12 +77,13 @@ class Client extends EventEmitter {
     this.tls_config = this.connectionParameters.tls_config
     this.tls_mode = this.connectionParameters.tls_mode || 'disable'
     this.tls_trusted_certs = this.connectionParameters.tls_trusted_certs
+    this._connectionTimeoutMillis = c.connectionTimeoutMillis || 0
+    this.workload = this.connectionParameters.workload
 
     delete this.connectionParameters.tls_config
     delete this.connectionParameters.tls_mode
     delete this.connectionParameters.tls_trusted_certs
 
-    this._connectionTimeoutMillis = c.connectionTimeoutMillis || 0
   }
 
   _errorAllQueries(err) {
@@ -496,6 +498,7 @@ class Client extends EventEmitter {
       user: params.user,
       database: params.database,
       protocol_version: params.protocol_version.toString(),
+      client_os_hostname: params.client_os_hostname
     }
 
     if (params.replication) {
@@ -510,10 +513,13 @@ class Client extends EventEmitter {
     if (params.options) {
       data.options = params.options
     }
-
     if (params.client_label) {
       data.client_label = params.client_label
     }
+    if (params.workload) {
+      data.workload = params.workload
+    }
+
 
     return data
   }

--- a/packages/vertica-nodejs/lib/client.js
+++ b/packages/vertica-nodejs/lib/client.js
@@ -15,7 +15,6 @@
 'use strict'
 
 var dns = require('dns')
-var os = require('os')
 var EventEmitter = require('events').EventEmitter
 var util = require('util')
 var utils = require('./utils')

--- a/packages/vertica-nodejs/lib/connection-parameters.js
+++ b/packages/vertica-nodejs/lib/connection-parameters.js
@@ -15,6 +15,7 @@
 'use strict'
 
 var dns = require('dns')
+var os = require('os')
 
 var defaults = require('./defaults')
 
@@ -112,6 +113,8 @@ class ConnectionParameters {
 
     this.backup_server_node = parseBackupServerNodes(val('backup_server_node', config))
     this.client_label = val('client_label', config, false)
+    this.workload = val('workload', config, false)
+    this.client_os_hostname = os.hostname()
     //NOTE: The client has only been tested to support 3.5, which was chosen in order to include SHA512 support
     this.protocol_version = (3 << 16 | 5) // 3.5 -> (major << 16 | minor) -> (3 << 16 | 5) -> 196613
 

--- a/packages/vertica-nodejs/lib/defaults.js
+++ b/packages/vertica-nodejs/lib/defaults.js
@@ -51,39 +51,27 @@ module.exports = {
   // max milliseconds a client can go unused before it is removed
   // from the pool and destroyed
   idleTimeoutMillis: 30000,
-
   client_encoding: '',
-
   tls_mode: 'disable',
-
   tls_key_file: undefined,
-
   tls_cert_file: undefined,
-
   options: undefined,
-
   parseInputDatesAsUTC: false,
-
   // max milliseconds any query using this connection will execute for before timing out in error.
   // false=unlimited
   statement_timeout: false,
-
   // Terminate any session with an open transaction that has been idle for longer than the specified duration in milliseconds
   // false=unlimited
   idle_in_transaction_session_timeout: false,
-
   // max milliseconds to wait for query to complete (client side)
   query_timeout: false,
-
   connect_timeout: 0,
-
   keepalives: 1,
-
   keepalives_idle: 0,
-
   // A string to identify the vertica-nodejs connection's session on the server
   client_label: '',
-
   // A comma separated string listing all backup nodes to connect to. Each node is a host-port pair separated by a colon.
   backup_server_node: '',
+  // workload associated with this session
+  workload: '',
 }


### PR DESCRIPTION
This PR contains addition of client_os_hostname, which is determined by the driver with the os package, and workload which is a user supplied connection property. Both are sent on the startup request message. Logging a separate issue for updating documentation to describe all individual connection parameters and their valid values