### PR TITLE
Adding client auditing session properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,5 +34,8 @@
     "arrowParens": "always",
     "trailingComma": "es5",
     "singleQuote": true
+  },
+  "dependencies": {
+    "vertica-nodejs": "^1.1.1"
   }
 }

--- a/packages/v-pool/package.json
+++ b/packages/v-pool/package.json
@@ -1,6 +1,6 @@
 {
   "name": "v-pool",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Connection pool for Vertica",
   "main": "index.js",
   "directories": {
@@ -35,6 +35,6 @@
     "mocha": "^7.1.2"
   },
   "peerDependencies": {
-    "vertica-nodejs": "1.1.0"
+    "vertica-nodejs": "1.1.1"
   }
 }

--- a/packages/vertica-nodejs/lib/client.js
+++ b/packages/vertica-nodejs/lib/client.js
@@ -511,7 +511,12 @@ class Client extends EventEmitter {
       user: params.user,
       database: params.database,
       protocol_version: params.protocol_version.toString(),
-      client_os_hostname: params.client_os_hostname
+      client_type: params.client_type,
+      client_version: params.client_version,
+      client_os: params.client_os,
+      client_os_user_name: params.client_os_user_name,
+      client_os_hostname: params.client_os_hostname,
+      client_pid: params.client_pid
     }
 
     if (params.replication) {
@@ -532,7 +537,6 @@ class Client extends EventEmitter {
     if (params.workload) {
       data.workload = params.workload
     }
-
 
     return data
   }

--- a/packages/vertica-nodejs/lib/connection-parameters.js
+++ b/packages/vertica-nodejs/lib/connection-parameters.js
@@ -114,7 +114,15 @@ class ConnectionParameters {
     this.backup_server_node = parseBackupServerNodes(val('backup_server_node', config))
     this.client_label = val('client_label', config, false)
     this.workload = val('workload', config, false)
+
+    // client auditing information
     this.client_os_hostname = os.hostname()
+    this.client_type = "Node.js Driver"
+    this.client_version = "1.1.1"
+    this.client_pid = process.pid.toString()
+    this.client_os = os.platform()
+    this.client_os_user_name = os.userInfo().username
+
     //NOTE: The client has only been tested to support 3.5, which was chosen in order to include SHA512 support
     this.protocol_version = (3 << 16 | 5) // 3.5 -> (major << 16 | minor) -> (3 << 16 | 5) -> 196613
 

--- a/packages/vertica-nodejs/lib/index.js
+++ b/packages/vertica-nodejs/lib/index.js
@@ -19,6 +19,7 @@ var defaults = require('./defaults')
 var Connection = require('./connection')
 var Pool = require('v-pool')
 const { DatabaseError } = require('v-protocol')
+const packageJson = require('../package.json')
 
 const poolFactory = (Client) => {
   return class BoundPool extends Pool {
@@ -28,7 +29,7 @@ const poolFactory = (Client) => {
   }
 }
 
-var PG = function (clientConstructor) {
+var Vertica = function (clientConstructor) {
   this.defaults = defaults
   this.Client = clientConstructor
   this.Query = this.Client.Query
@@ -37,7 +38,8 @@ var PG = function (clientConstructor) {
   this.Connection = Connection
   this.types = require('pg-types')
   this.DatabaseError = DatabaseError
+  this.version = packageJson.version
 }
 
-module.exports = new PG(Client)
+module.exports = new Vertica(Client)
 

--- a/packages/vertica-nodejs/mochatest/integration/client/vertica-connection-params-tests.js
+++ b/packages/vertica-nodejs/mochatest/integration/client/vertica-connection-params-tests.js
@@ -105,12 +105,17 @@ describe('vertica backup_server_node connection parameter', function() {
   })
 })
 
-describe('vertica client_os_hostname connection parameter', function() {
-  it('is automatically determined and sent in the startup packet', function() {
+describe('vertica-nodejs handling auditing connection properties', function() {
+  it('are provided automatically when establishing a connection', function() {
     const client = new vertica.Client()
     client.connect()
-    client.query("SELECT client_os_hostname FROM current_session", (err, res) => {
+    client.query("SELECT client_pid, client_type, client_version, client_os, client_os_user_name, client_os_hostname FROM CURRENT_SESSION", (err, res) => {
       if (err) assert(false)
+      assert.equal(res.rows[0].client_pid, process.pid)
+      assert.equal(res.rows[0].client_type, "Node.js Driver")
+      assert.equal(res.rows[0].client_version, "1.1.1")
+      assert.equal(res.rows[0].client_os, os.platform())
+      assert.equal(res.rows[0].client_os_user_name, os.userInfo().username)
       assert.equal(res.rows[0].client_os_hostname, os.hostname())
       client.end()
     })
@@ -131,3 +136,4 @@ describe('vertica workload connection parameter', function() {
     })
   })
 })
+

--- a/packages/vertica-nodejs/mochatest/integration/client/vertica-connection-params-tests.js
+++ b/packages/vertica-nodejs/mochatest/integration/client/vertica-connection-params-tests.js
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 'use strict'
-const vertica = require('../../../lib')
+const vertica = require('../../../../vertica-nodejs')
 const assert = require('assert')
 
 var os = require('os')
@@ -113,7 +113,7 @@ describe('vertica-nodejs handling auditing connection properties', function() {
       if (err) assert(false)
       assert.equal(res.rows[0].client_pid, process.pid)
       assert.equal(res.rows[0].client_type, "Node.js Driver")
-      assert.equal(res.rows[0].client_version, "1.1.1")
+      assert.equal(res.rows[0].client_version, vertica.version)
       assert.equal(res.rows[0].client_os, os.platform())
       assert.equal(res.rows[0].client_os_user_name, os.userInfo().username)
       assert.equal(res.rows[0].client_os_hostname, os.hostname())

--- a/packages/vertica-nodejs/package.json
+++ b/packages/vertica-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vertica-nodejs",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Vertica client - pure javascript & libpq with the same API",
   "keywords": [
     "database",
@@ -31,7 +31,7 @@
     "pg-types": "^2.1.0",
     "pgpass": "1.x",
     "v-connection-string": "1.1.0",
-    "v-pool": "1.1.0",
+    "v-pool": "1.1.1",
     "v-protocol": "1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Request to add automatic client auditing information as is available in vertica's sessions table.
Some were already available. Newly added properties are client_pid, client_type, client_version, client_os, and client_os_user_name