### PR TITLE
Password default change to empty string

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,10 @@ jobs:
     name: Node.js ${{ matrix.node }} (${{ matrix.os }})
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
           cache: yarn

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Ensure that the applicable environment variables are configured for connecting t
  - V_HOST: 'localhost'
  - V_PORT: 5433
  - V_USER: process.env.USER/USERNAME
- - V_PASSWORD: null
+ - V_PASSWORD: ''
  - V_DATABASE: ''
  - V_BACKUP_SERVER_NODE: ''
 

--- a/packages/vertica-nodejs/README.md
+++ b/packages/vertica-nodejs/README.md
@@ -44,7 +44,7 @@ Ensure that the applicable environment variables are configured for connecting t
  - V_HOST: 'localhost'
  - V_PORT: 5433
  - V_USER: process.env.USER/USERNAME
- - V_PASSWORD: null
+ - V_PASSWORD: ''
  - V_DATABASE: ''
  - V_BACKUP_SERVER_NODE: ''
 

--- a/packages/vertica-nodejs/lib/defaults.js
+++ b/packages/vertica-nodejs/lib/defaults.js
@@ -25,7 +25,7 @@ module.exports = {
   database: '',
 
   // database user's password
-  password: null,
+  password: '',
 
   // a Postgres connection string to be used instead of setting individual connection items
   // NOTE:  Setting this value will cause it to override any other value (such as database or user) defined

--- a/packages/vertica-nodejs/test/integration/client/configuration-tests.js
+++ b/packages/vertica-nodejs/test/integration/client/configuration-tests.js
@@ -15,7 +15,7 @@ suite.test('default values are used in new clients', function () {
   assert.same(vertica.defaults, {
     user: process.env.USER,
     database: '',
-    password: null,
+    password: '',
     port: 5433,
     rows: 0,
     max: 10,

--- a/packages/vertica-nodejs/test/integration/client/network-partition-tests.js
+++ b/packages/vertica-nodejs/test/integration/client/network-partition-tests.js
@@ -11,11 +11,11 @@ var Server = function (response) {
   this.response = response
 }
 
-let port = 54321
+let port = 5433
 Server.prototype.start = function (cb) {
-  // this is our fake postgres server
+  // this is our fake vertica server
   // it responds with our specified response immediatley after receiving every buffer
-  // this is sufficient into convincing the client its connectet to a valid backend
+  // this is sufficient into convincing the client its connect to a valid backend
   // if we respond with a readyForQuery message
   this.server = net.createServer(
     function (socket) {

--- a/packages/vertica-nodejs/test/unit/client/configuration-tests.js
+++ b/packages/vertica-nodejs/test/unit/client/configuration-tests.js
@@ -68,7 +68,7 @@ test('initializing from a config string', function () {
   test('when not including all values the defaults are used', function () {
     var client = new Client('postgres://host1')
     assert.equal(client.user, process.env['V_USER'] || process.env.USER)
-    assert.equal(client.password, process.env['V_PASSWORD'] || null)
+    assert.equal(client.password, process.env['V_PASSWORD'] || '')
     assert.equal(client.host, 'host1')
     assert.equal(client.port, process.env['V_PORT'] || 5433)
     assert.equal(client.database, process.env['V_DATABASE'] || '')


### PR DESCRIPTION
Cannot connect to a user with `''` as sha512 password. E.g. a dbadmin with following setting
```sql
CREATE AUTHENTICATION v_dbadmin_hash METHOD 'hash' HOST '0.0.0.0/0';
ALTER AUTHENTICATION v_dbadmin_hash PRIORITY 10000;
GRANT AUTHENTICATION v_dbadmin_hash TO dbadmin;
```
The client will overwrite password `''` to `null` and return an error message
```
TypeError [ERR_INVALID_ARG_TYPE]: The first argument must be of type string or an instance of Buffer, ArrayBuffer, or Array or an Array-like Object. Received null
    at new NodeError (node:internal/errors:371:5)
    at Function.from (node:buffer:322:9)
    at Object.postgresSha512PasswordHash (/home/sren/node_modules/vertica-nodejs/lib/utils.js:198:44)
    at /home/sren/node_modules/vertica-nodejs/lib/client.js:365:36
    at /home/sren/node_modules/vertica-nodejs/lib/client.js:318:9
    at /home/sren/node_modules/pgpass/lib/index.js:14:20
    at FSReqCallback.oncomplete (node:fs:198:21) {
  code: 'ERR_INVALID_ARG_TYPE'
}
```
Nodejs driver uses `null` as password default value. Other vertica drivers use empty string as password default value, it's better to change nodejs driver's default and solve above bug as well.