### PR TITLE
TLS verify-full fix host

### DIFF
--- a/packages/vertica-nodejs/lib/client.js
+++ b/packages/vertica-nodejs/lib/client.js
@@ -65,6 +65,7 @@ class Client extends EventEmitter {
         tls_config: this.connectionParameters.tls_config,
         tls_mode: this.connectionParameters.tls_mode,
         tls_trusted_certs: this.connectionParameters.tls_trusted_certs,
+        tls_host: this.connectionParameters.host,
         keepAlive: c.keepAlive || false,
         keepAliveInitialDelayMillis: c.keepAliveInitialDelayMillis || 0,
         encoding: this.connectionParameters.client_encoding || 'utf8',

--- a/packages/vertica-nodejs/lib/connection.js
+++ b/packages/vertica-nodejs/lib/connection.js
@@ -50,6 +50,7 @@ class Connection extends EventEmitter {
       //this.tls_client_key = config.tls_client_key
       //this.tls_client_cert = config.tls_client_cert
       this.tls_trusted_certs = config.tls_trusted_certs
+      this.tls_host = config.tls_host
     }
     var self = this
     this.on('newListener', function (eventName) {
@@ -166,6 +167,7 @@ class Connection extends EventEmitter {
         else if (self.tls_mode === 'verify-full') { //verify that the name on the CA-signed server certificate matches it's hostname
           try {
             tls_options.rejectUnauthorized = true
+            tls_options.host = self.tls_host  // Hostname/IP to match certificate's altnames
             if (self.tls_trusted_certs) {
               tls_options.ca = fs.readFileSync(self.tls_trusted_certs).toString()
             }


### PR DESCRIPTION
When connect to a remote server with tls_mode = 'verify-full', the client throws an error message `Hostname/IP does not match certificate's altnames: Host: localhost. is not in the cert's altnames: DNS:abc.example.com`.

This is because the nodejs [tls](https://nodejs.org/api/tls.html#tlsconnectoptions-callback) module uses 'localhost' as the default host when checking the server's host name against the certificate. This PR takes the user input host (not DNS resolved or load balanced) and pass to the tls_options for verifying the certificate. This doesn't change the host the socket should connect to.