### PR TITLE
Version updates for vertica-nodejs 1.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
     "singleQuote": true
   },
   "dependencies": {
-    "vertica-nodejs": "^1.1.2"
+    "vertica-nodejs": "^1.1.3"
   }
 }

--- a/packages/v-pool/package.json
+++ b/packages/v-pool/package.json
@@ -1,6 +1,6 @@
 {
   "name": "v-pool",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Connection pool for Vertica",
   "main": "index.js",
   "directories": {
@@ -35,6 +35,6 @@
     "mocha": "^7.1.2"
   },
   "peerDependencies": {
-    "vertica-nodejs": "1.1.2"
+    "vertica-nodejs": "1.1.3"
   }
 }

--- a/packages/vertica-nodejs/lib/connection-parameters.js
+++ b/packages/vertica-nodejs/lib/connection-parameters.js
@@ -117,7 +117,7 @@ class ConnectionParameters {
 
     // client auditing information
     this.client_type = "Node.js Driver"
-    this.client_version = "1.1.2"
+    this.client_version = "1.1.3"
 
     try {
       this.client_os_hostname = os.hostname()

--- a/packages/vertica-nodejs/package.json
+++ b/packages/vertica-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vertica-nodejs",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Vertica client - pure javascript & libpq with the same API",
   "keywords": [
     "database",
@@ -32,7 +32,7 @@
     "pg-types": "^2.1.0",
     "pgpass": "1.x",
     "v-connection-string": "1.1.0",
-    "v-pool": "1.1.2",
+    "v-pool": "1.1.3",
     "v-protocol": "1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Package version updates for vertica-nodejs 1.1.3

Changes since last release are only within vertica-nodejs package. Which means only updates needing to be made are for vertica-nodejs and v-pool because v-pool has vertica-nodejs as a peer dependency. 