### PR TITLE
Fix copy local reject files larger than buffer size

### DIFF
--- a/packages/vertica-nodejs/lib/query.js
+++ b/packages/vertica-nodejs/lib/query.js
@@ -337,7 +337,7 @@ class Query extends EventEmitter {
     if (msg.fileName.length === 0) { //using returnrejected, fileContents is an array of row numbers, not a string
       this._result._setRejectedRows(msg.fileContents)
     } else { // future enhancement, move file IO to util
-      fs.appendFile(msg.fileName, msg.fileContents, (err) => {
+      await fs.appendFile(msg.fileName, msg.fileContents, (err) => {
         if (err) {
           console.error('Error writing to file:', err);
         }

--- a/packages/vertica-nodejs/lib/query.js
+++ b/packages/vertica-nodejs/lib/query.js
@@ -337,7 +337,7 @@ class Query extends EventEmitter {
     if (msg.fileName.length === 0) { //using returnrejected, fileContents is an array of row numbers, not a string
       this._result._setRejectedRows(msg.fileContents)
     } else { // future enhancement, move file IO to util
-      await fs.appendFile(msg.fileName, msg.fileContents, (err) => {
+      fs.appendFileSync(msg.fileName, msg.fileContents, (err) => {
         if (err) {
           console.error('Error writing to file:', err);
         }

--- a/packages/vertica-nodejs/mochatest/integration/client/copy-local-file-tests.js
+++ b/packages/vertica-nodejs/mochatest/integration/client/copy-local-file-tests.js
@@ -175,8 +175,10 @@ describe('Running Copy From Local File Commands', function () {
     
         fs.stat('rejects-large.txt', (statErr, stats) => {
           assert.equal(statErr, null);
-          assert.equal(stats.size, 98894);
         });
+        var inputBuf = fs.readFileSync('large-copy-bad.dat');
+        var rejectBuf = fs.readFileSync('rejects-large.txt');
+        assert(inputBuf.equals(rejectBuf), 'content in rejected data file is not the same as the input file')
       } finally {
         fs.unlink('large-copy-bad.dat', () => {
           fs.unlink('rejects-large.txt', done)


### PR DESCRIPTION
There is a nondeterministic test failure in `copy-local-file-tests.js`, which is caused by `fs.appendFile()` asynchronously append multiple WriteFile data to a reject file. Multiple WriteFile data should write to the reject file in order.