### PR TITLE
Improve client_os value in the session information

### DIFF
--- a/packages/vertica-nodejs/lib/connection-parameters.js
+++ b/packages/vertica-nodejs/lib/connection-parameters.js
@@ -144,7 +144,7 @@ class ConnectionParameters {
     }
 
     try {
-      this.client_os = os.platform()
+      this.client_os = [os.type(), os.release(), os.machine()].join(' ')
     } catch (e) {
       this.client_os = ""
     }

--- a/packages/vertica-nodejs/lib/connection-parameters.js
+++ b/packages/vertica-nodejs/lib/connection-parameters.js
@@ -146,7 +146,15 @@ class ConnectionParameters {
     try {
       this.client_os = [os.type(), os.release(), os.machine()].join(' ')
     } catch (e) {
-      this.client_os = ""
+      if (e instanceof TypeError) {
+        try {
+          this.client_os = [os.type(), os.release(), os.arch()].join(' ')
+        } catch (ex) {
+          this.client_os = ""
+        }
+      } else {
+        this.client_os = ""
+      }
     }
 
     try {

--- a/packages/vertica-nodejs/mochatest/integration/client/vertica-connection-params-tests.js
+++ b/packages/vertica-nodejs/mochatest/integration/client/vertica-connection-params-tests.js
@@ -31,12 +31,12 @@ describe('vertica client label connection parameter', function () {
       if (err){
         console.log(err)
         done(err)
-      } 
+      }
       assert.equal(res.rows[0]['GET_CLIENT_LABEL'], vertica.defaults.client_label)
       client_default.end()
       done()
     })
-  })    
+  })
 
   it('can be specified and used in a client connection', function(done) {
     // assert creating a client connection with specified label will persist
@@ -47,7 +47,7 @@ describe('vertica client label connection parameter', function () {
       if (err){
         console.log(err)
         done(err)
-      } 
+      }
       assert.equal(res.rows[0]['GET_CLIENT_LABEL'], 'distinctLabel')
       client_test.end()
       done()
@@ -114,7 +114,7 @@ describe('vertica-nodejs handling auditing connection properties', function() {
       assert.equal(res.rows[0].client_pid, process.pid)
       assert.equal(res.rows[0].client_type, "Node.js Driver")
       assert.equal(res.rows[0].client_version, vertica.version)
-      assert.equal(res.rows[0].client_os, os.platform())
+      assert.equal(res.rows[0].client_os, [os.type(), os.release(), os.machine()].join(' '))
       assert.equal(res.rows[0].client_os_user_name, os.userInfo().username)
       assert.equal(res.rows[0].client_os_hostname, os.hostname())
       client.end()
@@ -127,7 +127,7 @@ describe('vertica workload connection parameter', function() {
   it('can be set and is sent in the startup packet', function(done) {
     const client = new vertica.Client({workload: 'testNodeWorkload'})
     client.connect()
-    client.query(`SELECT contents FROM dc_client_server_messages 
+    client.query(`SELECT contents FROM dc_client_server_messages
                   WHERE session_id = current_session()
                   AND message_type = '^+'
                   AND contents like '%workload%'`, (err, res) => {

--- a/packages/vertica-nodejs/mochatest/integration/client/vertica-connection-params-tests.js
+++ b/packages/vertica-nodejs/mochatest/integration/client/vertica-connection-params-tests.js
@@ -110,11 +110,25 @@ describe('vertica-nodejs handling auditing connection properties', function() {
     const client = new vertica.Client()
     client.connect()
     client.query("SELECT client_pid, client_type, client_version, client_os, client_os_user_name, client_os_hostname FROM CURRENT_SESSION", (err, res) => {
+      var client_os
+      try {
+        client_os = [os.type(), os.release(), os.machine()].join(' ')
+      } catch (e) {
+        if (e instanceof TypeError) {
+          try {
+            client_os = [os.type(), os.release(), os.arch()].join(' ')
+          } catch (ex) {
+            client_os = ''
+          }
+        } else {
+          client_os = ''
+        }
+      }
       if (err) done(err)
       assert.equal(res.rows[0].client_pid, process.pid)
       assert.equal(res.rows[0].client_type, "Node.js Driver")
       assert.equal(res.rows[0].client_version, vertica.version)
-      assert.equal(res.rows[0].client_os, [os.type(), os.release(), os.machine()].join(' '))
+      assert.equal(res.rows[0].client_os, client_os)
       assert.equal(res.rows[0].client_os_user_name, os.userInfo().username)
       assert.equal(res.rows[0].client_os_hostname, os.hostname())
       client.end()


### PR DESCRIPTION
Currently, vertica-nodejs uses the os.platform()'s output as the client_os value in the session information. To set more helpful information like the value set by vsql, it needs to use os.type(), os.release(), and os.machine() to generate the value. However, os.machine() doesn't exist in Node.js 12 and 14. So I chose os.arch() to replace it only for both releases.

'mochatest/integration/client/vertica-connection-params-tests.js' has a test case to check the client_os value in the session information. I also modified this test case.

CI has been passed.