### PR TITLE
Wrong INTEGER value was returned #156

### DIFF
--- a/packages/vertica-nodejs/lib/type-overrides.js
+++ b/packages/vertica-nodejs/lib/type-overrides.js
@@ -17,10 +17,10 @@
 const { VerticaType } = require('v-protocol')
 var types = require('pg-types')
 
-// this is a 'temporary' solution allowing us to continue to use pg-types as long as we can to avoid another large 
+// this is a 'temporary' solution allowing us to continue to use pg-types as long as we can to avoid another large
 // package implementation while we get close to the 1.0 release
 types.setTypeParser(VerticaType.Boolean, types.getTypeParser(16, 'text'))
-types.setTypeParser(VerticaType.Integer, types.getTypeParser(21, 'text'))
+types.setTypeParser(VerticaType.Integer, types.getTypeParser(20, 'text'))
 types.setTypeParser(VerticaType.Float, types.getTypeParser(700, 'text'))
 types.setTypeParser(VerticaType.Numeric, types.getTypeParser(9, 'text'))
 types.setTypeParser(VerticaType.Varbinary, types.getTypeParser(9, 'text'))

--- a/packages/vertica-nodejs/lib/type-overrides.js
+++ b/packages/vertica-nodejs/lib/type-overrides.js
@@ -17,7 +17,7 @@
 const { VerticaType } = require('v-protocol')
 var types = require('pg-types')
 
-// this is a 'temporary' solution allowing us to continue to use pg-types as long as we can to avoid another large
+// this is a 'temporary' solution allowing us to continue to use pg-types as long as we can to avoid another large 
 // package implementation while we get close to the 1.0 release
 types.setTypeParser(VerticaType.Boolean, types.getTypeParser(16, 'text'))
 types.setTypeParser(VerticaType.Integer, types.getTypeParser(20, 'text'))


### PR DESCRIPTION
Wrong INTEGER value was returned #156


import vertica from "vertica-nodejs";
const { Client } = vertica;

const client = new Client("vertica://dbadmin:@host:5433/dbname");
client.connect();
client.query("SELECT CAST(205900366134250666 AS VARCHAR) AS keyCast, 205900366134250666 AS keyOrig;", (err, res) => {
  console.log(err || res.rows[0]);
  client.end();
});

output:

# node main.js 
{ keyCast: '**205900366134250666**', keyOrig: **205900366134250660** }