### PR TITLE
Enhance client_os reporting for vertica-nodejs

### DIFF
--- a/packages/vertica-nodejs/lib/connection-parameters.js
+++ b/packages/vertica-nodejs/lib/connection-parameters.js
@@ -144,9 +144,13 @@ class ConnectionParameters {
     }
 
     try {
-      this.client_os = os.platform()
+      this.client_os = `${os.type()} ${os.release()} ${os.arch()}`
     } catch (e) {
-      this.client_os = ""
+      try {
+        this.client_os = os.platform()
+      } catch (e2) {
+        this.client_os = "unknown"
+      }
     }
 
     try {

--- a/packages/vertica-nodejs/mochatest/integration/client/vertica-connection-params-tests.js
+++ b/packages/vertica-nodejs/mochatest/integration/client/vertica-connection-params-tests.js
@@ -114,7 +114,7 @@ describe('vertica-nodejs handling auditing connection properties', function() {
       assert.equal(res.rows[0].client_pid, process.pid)
       assert.equal(res.rows[0].client_type, "Node.js Driver")
       assert.equal(res.rows[0].client_version, vertica.version)
-      assert.equal(res.rows[0].client_os, os.platform())
+      assert.equal(res.rows[0].client_os, `${os.type()} ${os.release()} ${os.arch()}`)
       assert.equal(res.rows[0].client_os_user_name, os.userInfo().username)
       assert.equal(res.rows[0].client_os_hostname, os.hostname())
       client.end()

--- a/packages/vertica-nodejs/test/unit/connection-parameters/client-os-tests.js
+++ b/packages/vertica-nodejs/test/unit/connection-parameters/client-os-tests.js
@@ -1,0 +1,52 @@
+'use strict'
+const helper = require('../test-helper')
+const assert = require('assert')
+const os = require('os')
+const ConnectionParameters = require('../../../lib/connection-parameters')
+
+const suite = new helper.Suite()
+
+suite.test('client_os provides detailed OS string', function () {
+  const subject = new ConnectionParameters()
+  const expected = `${os.type()} ${os.release()} ${os.arch()}`
+  assert.equal(subject.client_os, expected)
+})
+
+suite.test('client_os falls back to os.platform() when detailed retrieval fails', function () {
+  const originalType = os.type
+  const originalRelease = os.release
+  const originalArch = os.arch
+  try {
+    os.type = function () { throw new Error('type fail') }
+    os.release = function () { throw new Error('release fail') }
+    os.arch = function () { throw new Error('arch fail') }
+
+    const subject = new ConnectionParameters()
+    assert.equal(subject.client_os, os.platform())
+  } finally {
+    os.type = originalType
+    os.release = originalRelease
+    os.arch = originalArch
+  }
+})
+
+suite.test('client_os uses "unknown" when both detailed and platform retrieval fail', function () {
+  const originalType = os.type
+  const originalRelease = os.release
+  const originalArch = os.arch
+  const originalPlatform = os.platform
+  try {
+    os.type = function () { throw new Error('type fail') }
+    os.release = function () { throw new Error('release fail') }
+    os.arch = function () { throw new Error('arch fail') }
+    os.platform = function () { throw new Error('platform fail') }
+
+    const subject = new ConnectionParameters()
+    assert.equal(subject.client_os, 'unknown')
+  } finally {
+    os.type = originalType
+    os.release = originalRelease
+    os.arch = originalArch
+    os.platform = originalPlatform
+  }
+})


### PR DESCRIPTION
This MR enhances the client_os value reported by the Vertica Node.js driver in session information.
Instead of returning generic values such as linux or win32, the driver now reports a detailed and meaningful OS string, consistent with other Vertica client drivers (vertica-python, ODBC, JDBC).

Problem Statement

Currently, when connecting using vertica-nodejs, the client_os field contains only basic OS identifiers.
Customers expect richer OS information in v_monitor.sessions, similar to what is provided by other supported drivers.

Solution

Updated client_os to include OS type, release, and architecture.
Added robust fallback handling:
Falls back to os.platform() if detailed OS retrieval fails.
Uses "unknown" if all OS lookups fail.
Ensured output consistency with other Vertica client drivers.

Changes Included

connection-parameters.js
Enhanced client_os construction with detailed OS information and fallback logic.
Integration test update
Updated expectations to validate the new client_os format.
New unit tests
Added coverage for:
Detailed OS reporting
Fallback to os.platform()
Final fallback to "unknown"
<img width="658" height="153" alt="os_issue_fix" src="https://github.com/user-attachments/assets/3353ece3-e366-4d59-b6b9-9a951b41f794" />
